### PR TITLE
Feature/add example routes

### DIFF
--- a/src/Elewant/FrontendBundle/Controller/DefaultController.php
+++ b/src/Elewant/FrontendBundle/Controller/DefaultController.php
@@ -10,7 +10,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class DefaultController extends Controller
 {
     /**
-     * @Route("/")
+     * @Route("/", name="root")
      */
     public function indexAction()
     {

--- a/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
+++ b/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\FrontendBundle\Controller;
+
+use Elewant\Herding\Model\Commands\AbandonElePHPant;
+use Elewant\Herding\Model\Commands\AdoptElePHPant;
+use Elewant\Herding\Model\Commands\FormHerd;
+use Elewant\Herding\Projections\HerdListing;
+use Prooph\ServiceBus\CommandBus;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+/**
+ * @Route("/example")
+ */
+class HerdingExampleController extends Controller
+{
+    private $shepherdId = '00000000-0000-0000-0000-000000000000';
+    private $herdNameSeed = ['honey','rob','delight','change','merciful','achiever','match','quick','spare',
+                             'chubby','grain','frame','division','nose','reply','icicle','improve','wool','amusing',
+                             'meek','substantial','bee','earn','word'];
+
+    /**
+     * @Route("/", name="herd_list")
+     */
+    public function testingListAction()
+    {
+        /** @var HerdListing $herdListing */
+        $herdListing = $this->container->get('elewant.herd_projection.herd_listing');
+
+        $herds = $herdListing->findAll();
+
+        return $this->render('ElewantFrontendBundle:Default:herd_list.html.twig', ['herds' => $herds]);
+    }
+
+    /**
+     * @Route("/form", name="herd_form")
+     */
+    public function testingFormAdoptAction()
+    {
+        /** @var CommandBus $commandBus */
+        $commandBus = $this->get('prooph_service_bus.herding_command_bus');
+        shuffle($this->herdNameSeed);
+        $herdName = ucfirst(implode(' ', array_slice($this->herdNameSeed, 0, 3)));
+
+        $command = FormHerd::forShepherd($this->shepherdId, $herdName);
+        $commandBus->dispatch($command);
+
+        return $this->redirectToRoute('herd_list');
+    }
+
+    /**
+     * @Route("/{herdId}", name="herd_show")
+     */
+    public function testingHerdAction($herdId)
+    {
+        /** @var HerdListing $herdListing */
+        $herdListing = $this->container->get('elewant.herd_projection.herd_listing');
+
+        $herd       = $herdListing->findById($herdId);
+        $elephpants = $herdListing->findElephpantsByHerdId($herdId);
+
+        $data = [
+            'herd'       => $herd,
+            'elephpants' => $elephpants,
+        ];
+
+        return $this->render('ElewantFrontendBundle:Default:herd_show.html.twig', $data);
+    }
+
+    /**
+     * @Route("/{herdId}/adopt/{breed}", name="herd_adopt")
+     */
+    public function testingHerdAdoptAction($herdId, $breed)
+    {
+        /** @var CommandBus $commandBus */
+        $commandBus = $this->get('prooph_service_bus.herding_command_bus');
+        $command    = AdoptElePHPant::byHerd($herdId, $breed);
+
+        $commandBus->dispatch($command);
+
+        return $this->redirectToRoute('herd_show', ['herdId' => $herdId]);
+    }
+
+    /**
+     * @Route("/{herdId}/abandon/{breed}", name="herd_abandon")
+     */
+    public function testingHerdAbandonAction($herdId, $breed)
+    {
+        /** @var CommandBus $commandBus */
+        $commandBus = $this->get('prooph_service_bus.herding_command_bus');
+        $command    = AbandonElePHPant::byHerd($herdId, $breed);
+
+        $commandBus->dispatch($command);
+
+        return $this->redirectToRoute('herd_show', ['herdId' => $herdId]);
+    }
+
+
+}

--- a/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
+++ b/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
@@ -25,8 +25,12 @@ class HerdingExampleController extends Controller
     /**
      * @Route("/", name="herd_list")
      */
-    public function testingListAction()
+    public function listHerdsAction()
     {
+        if ($this->accessNotAllowed()) {
+            return $this->redirectToRoute('root');
+        }
+
         /** @var HerdListing $herdListing */
         $herdListing = $this->container->get('elewant.herd_projection.herd_listing');
 
@@ -38,8 +42,12 @@ class HerdingExampleController extends Controller
     /**
      * @Route("/form", name="herd_form")
      */
-    public function testingFormAdoptAction()
+    public function formHerdAction()
     {
+        if ($this->accessNotAllowed()) {
+            return $this->redirectToRoute('root');
+        }
+
         /** @var CommandBus $commandBus */
         $commandBus = $this->get('prooph_service_bus.herding_command_bus');
         shuffle($this->herdNameSeed);
@@ -54,8 +62,12 @@ class HerdingExampleController extends Controller
     /**
      * @Route("/{herdId}", name="herd_show")
      */
-    public function testingHerdAction($herdId)
+    public function showHerdAction($herdId)
     {
+        if ($this->accessNotAllowed()) {
+            return $this->redirectToRoute('root');
+        }
+
         /** @var HerdListing $herdListing */
         $herdListing = $this->container->get('elewant.herd_projection.herd_listing');
 
@@ -73,8 +85,12 @@ class HerdingExampleController extends Controller
     /**
      * @Route("/{herdId}/adopt/{breed}", name="herd_adopt")
      */
-    public function testingHerdAdoptAction($herdId, $breed)
+    public function adoptElePHPantAction($herdId, $breed)
     {
+        if ($this->accessNotAllowed()) {
+            return $this->redirectToRoute('root');
+        }
+
         /** @var CommandBus $commandBus */
         $commandBus = $this->get('prooph_service_bus.herding_command_bus');
         $command    = AdoptElePHPant::byHerd($herdId, $breed);
@@ -87,8 +103,12 @@ class HerdingExampleController extends Controller
     /**
      * @Route("/{herdId}/abandon/{breed}", name="herd_abandon")
      */
-    public function testingHerdAbandonAction($herdId, $breed)
+    public function abandonElePHPantAction($herdId, $breed)
     {
+        if ($this->accessNotAllowed()) {
+            return $this->redirectToRoute('root');
+        }
+
         /** @var CommandBus $commandBus */
         $commandBus = $this->get('prooph_service_bus.herding_command_bus');
         $command    = AbandonElePHPant::byHerd($herdId, $breed);
@@ -98,5 +118,7 @@ class HerdingExampleController extends Controller
         return $this->redirectToRoute('herd_show', ['herdId' => $herdId]);
     }
 
-
+    private function accessNotAllowed() {
+        return !$this->get('kernel')->isDebug();
+    }
 }

--- a/src/Elewant/FrontendBundle/Resources/config/projection.yml
+++ b/src/Elewant/FrontendBundle/Resources/config/projection.yml
@@ -1,4 +1,8 @@
 services:
+  elewant.herd_projection.herd_listing:
+    class: Elewant\Herding\Projections\HerdListing
+    arguments: ['@doctrine.dbal.default_connection']
+
   elewant.herd_projection.herd_projector:
     class: Elewant\Herding\Projections\HerdProjector
     arguments: ['@doctrine.dbal.default_connection']

--- a/src/Elewant/FrontendBundle/Resources/views/Default/herd_list.html.twig
+++ b/src/Elewant/FrontendBundle/Resources/views/Default/herd_list.html.twig
@@ -1,0 +1,11 @@
+{% extends 'ElewantFrontendBundle::layout.html.twig' %}
+
+{% block body %}
+    <p><a href="{{ path('herd_form') }}">Form a new herd</a></p>
+
+    {% for herd in herds %}
+        <a href="{{ path('herd_show', {'herdId': herd.herd_id}) }}">
+            {{ herd.name }} ({{ herd.herd_id }})
+        </a><br />
+    {% endfor %}
+{% endblock %}

--- a/src/Elewant/FrontendBundle/Resources/views/Default/herd_show.html.twig
+++ b/src/Elewant/FrontendBundle/Resources/views/Default/herd_show.html.twig
@@ -1,0 +1,20 @@
+{% extends 'ElewantFrontendBundle::layout.html.twig' %}
+
+{% block body %}
+    <p><a href="{{ path('herd_list') }}">Back to herd list</a></p>
+
+    <ul>
+        <li>Name: {{ herd.name }}</li>
+        <li>HerdId: {{ herd.herd_id }}</li>
+        <li>ShepherdId: {{ herd.shepherd_id }}</li>
+        <li>Formed on: {{ herd.formed_on }}</li>
+    </ul>
+
+    <a href="{{ path('herd_adopt', {'herdId': herd.herd_id, 'breed': 'BLUE_ORIGINAL_REGULAR'}) }}">Adopt an original blue elephpant</a><br />
+    <a href="{{ path('herd_adopt', {'herdId': herd.herd_id, 'breed': 'BLACK_AMSTERDAMPHP_REGULAR'}) }}">Adopt an amsterdamPHP elephpant</a><br />
+    <a href="{{ path('herd_adopt', {'herdId': herd.herd_id, 'breed': 'WHITE_CONFOO_LARGE'}) }}">Adopt a ConFoo elephpant</a><br />
+
+    {% for elephpant in elephpants %}
+        {{ elephpant.breed }}<a href="{{ path('herd_abandon', {'herdId': herd.herd_id, 'breed': elephpant.breed}) }}">(abandon)</a></br >
+    {% endfor %}
+{% endblock %}

--- a/src/Elewant/Herding/Model/Handlers/AbandonElePHPantHandler.php
+++ b/src/Elewant/Herding/Model/Handlers/AbandonElePHPantHandler.php
@@ -24,7 +24,7 @@ final class AbandonElePHPantHandler
     {
         $herd = $this->herdCollection->get($command->herdId());
         if (!$herd) {
-            SorryIDoNotHaveThat::herd($command->herdId());
+            throw SorryIDoNotHaveThat::herd($command->herdId());
         }
 
         $herd->abandonElePHPant($command->breed());

--- a/src/Elewant/Herding/Model/Handlers/AdoptElePHPantHandler.php
+++ b/src/Elewant/Herding/Model/Handlers/AdoptElePHPantHandler.php
@@ -24,7 +24,7 @@ final class AdoptElePHPantHandler
     {
         $herd = $this->herdCollection->get($command->herdId());
         if (!$herd) {
-            SorryIDoNotHaveThat::herd($command->herdId());
+            throw SorryIDoNotHaveThat::herd($command->herdId());
         }
 
         $herd->adoptElePHPant($command->breed());

--- a/src/Elewant/Herding/Projections/HerdListing.php
+++ b/src/Elewant/Herding/Projections/HerdListing.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\Herding\Projections;
+
+use Doctrine\DBAL\Connection;
+
+final class HerdListing
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function findAll(): array
+    {
+        return $this->connection->fetchAll(sprintf('SELECT * FROM %s', HerdProjector::TABLE_HERD));
+    }
+
+    public function findById($herdId): array
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('*')
+            ->from(HerdProjector::TABLE_HERD)
+            ->where('herd_id = :herdId')
+            ->setParameter('herdId', $herdId);
+
+        return $qb->execute()->fetch();
+    }
+
+    public function findElePHPantsByHerdId($herdId) : array
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('*')
+            ->from(HerdProjector::TABLE_ELEPHPANT)
+            ->where('herd_id = :herdId')
+            ->setParameter('herdId', $herdId);
+
+        return $qb->execute()->fetchAll();
+    }
+
+}

--- a/src/Elewant/Herding/Projections/HerdProjector.php
+++ b/src/Elewant/Herding/Projections/HerdProjector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Elewant\Herding\Projections;
 
 use Doctrine\DBAL\Connection;


### PR DESCRIPTION
This PR ads an `/example`  route there you can play with herd management for a single (hardcoded) shepherdId.

It might need some love as we do not want the example to go to the production environment, which I have done in a horribly horrible way.