### PR TITLE
Add console command to rebuild projection and purge event stream

### DIFF
--- a/src/Elewant/FrontendBundle/Command/PurgeEventStoreCommand.php
+++ b/src/Elewant/FrontendBundle/Command/PurgeEventStoreCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\FrontendBundle\Command;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class PurgeEventStoreCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this->setName('eventstore:herd:purge');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion('<error>CAUTION! This will empty the Event store, are you sure? (y/N)</error>', false);
+
+        if (!$helper->ask($input, $output, $question)) {
+            return;
+        }
+
+        /** @var Connection $connection */
+        $connection = $this->getContainer()->get('doctrine.dbal.default_connection');
+        $connection->executeUpdate('truncate table event_stream');
+    }
+}

--- a/src/Elewant/FrontendBundle/Command/RebuildHerdProjectionCommand.php
+++ b/src/Elewant/FrontendBundle/Command/RebuildHerdProjectionCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\FrontendBundle\Command;
+
+use Elewant\Herding\Projections\HerdProjector;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Stream\StreamName;
+use Prooph\ServiceBus\EventBus;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RebuildHerdProjectionCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this->setName('projection:herd:rebuild');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var HerdProjector $herdProjector */
+        $herdProjector = $this->getContainer()->get('elewant.herd_projection.herd_projector');
+        $herdProjector->clearAllTables();
+
+        /** @var EventStore $eventStore */
+        $eventStore = $this->getContainer()->get('prooph_event_store.herd_store');
+        $streamName = new StreamName('event');
+        $iterator   = $eventStore->replay([$streamName]);
+
+        /** @var EventBus $replayBus */
+        $replayBus = $this->getContainer()->get('prooph_service_bus.herd_replay_bus');
+        foreach ($iterator as $key => $event) {
+            $replayBus->dispatch($event);
+        };
+    }
+}

--- a/src/Elewant/FrontendBundle/Resources/config/service_bus.yml
+++ b/src/Elewant/FrontendBundle/Resources/config/service_bus.yml
@@ -25,3 +25,19 @@ prooph_service_bus:
 
           'Elewant\Herding\Model\Events\ElePHPantWasAbandonedByHerd':
             - 'elewant.herd_projection.herd_projector'
+
+    herd_replay_bus:
+      plugins:
+        - 'prooph_service_bus.on_event_invoke_strategy'
+      router:
+        type: 'prooph_service_bus.event_bus_router'
+        routes:
+          'Elewant\Herding\Model\Events\HerdWasFormed':
+            - 'elewant.herd_projection.herd_projector'
+
+          'Elewant\Herding\Model\Events\ElePHPantWasAdoptedByHerd':
+            - 'elewant.herd_projection.herd_projector'
+
+          'Elewant\Herding\Model\Events\ElePHPantWasAbandonedByHerd':
+            - 'elewant.herd_projection.herd_projector'
+

--- a/src/Elewant/Herding/Projections/HerdProjector.php
+++ b/src/Elewant/Herding/Projections/HerdProjector.php
@@ -59,4 +59,10 @@ final class HerdProjector
             ]
         );
     }
+
+    public function clearAllTables()
+    {
+        $this->connection->executeUpdate(sprintf('truncate table %s', self::TABLE_ELEPHPANT));
+        $this->connection->executeUpdate(sprintf('truncate table %s', self::TABLE_HERD));
+    }
 }


### PR DESCRIPTION
This PR adds two console commands to the project. They are mainly for convenience during development:

`eventstore:herd:purge` - deletes all the events in the eventstore (destructive! asks confirmation)
`projections:herd:rebuild` - removes all entries from the herd and elephpant tables and replays all the events in the special "herd_replay" stream to rebuild them.

So in the future, we should not attach one-time-only listeners (like confirmation emails etc) to the replay stream.