### PR TITLE
Add trivially simple view for top5 lists in example

### DIFF
--- a/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
+++ b/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
@@ -61,6 +61,24 @@ class HerdingExampleController extends Controller
     }
 
     /**
+     * @Route("/top5", name="herd_top_5")
+     */
+    public function top5Action()
+    {
+        if ($this->accessNotAllowed()) {
+            return $this->redirectToRoute('root');
+        }
+
+        /** @var HerdListing $herdListing */
+        $herdListing = $this->container->get('elewant.herd_projection.herd_listing');
+
+        $herds = $herdListing->lastNewHerds(5);
+        $elePHPants = $herdListing->lastNewElePHPants(5);
+
+        return $this->render('ElewantFrontendBundle:Example:top5.html.twig', ['herds' => $herds, 'elephpants' => $elePHPants]);
+    }
+
+    /**
      * @Route("/{herdId}", name="herd_show")
      */
     public function showHerdAction($herdId)
@@ -136,7 +154,6 @@ class HerdingExampleController extends Controller
 
         return $this->redirectToRoute('herd_list');
     }
-
 
     private function accessNotAllowed() {
         return !$this->get('kernel')->isDebug();

--- a/src/Elewant/FrontendBundle/Resources/views/Example/herd_list.html.twig
+++ b/src/Elewant/FrontendBundle/Resources/views/Example/herd_list.html.twig
@@ -1,10 +1,14 @@
 {% extends 'ElewantFrontendBundle::layout.html.twig' %}
 
 {% block body %}
-    <p><a href="{{ path('herd_form') }}">Form a new herd</a></p>
+    <p><a href="{{ path('herd_top_5') }}">View top5 lists</a></p>
 
+    <p>
     {% for herd in herds %}
         <a href="{{ path('herd_show', {'herdId': herd.herd_id}) }}">{{ herd.name }}</a>
         <a href="{{ path('herd_abandon', {'herdId': herd.herd_id}) }}">(abandon)</a><br />
     {% endfor %}
+    </p>
+
+    <p><a href="{{ path('herd_form') }}">Form a new herd</a></p>
 {% endblock %}

--- a/src/Elewant/FrontendBundle/Resources/views/Example/herd_show.html.twig
+++ b/src/Elewant/FrontendBundle/Resources/views/Example/herd_show.html.twig
@@ -3,13 +3,15 @@
 {% block body %}
     <p><a href="{{ path('herd_list') }}">Back to herd list</a></p>
 
+    <p>
     <ul>
         <li>Name: {{ herd.name }}</li>
         <li>HerdId: {{ herd.herd_id }}</li>
         <li>ShepherdId: {{ herd.shepherd_id }}</li>
         <li>Formed on: {{ herd.formed_on }}</li>
     </ul>
-
+    </p>
+    
     <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herd_id, 'breed': 'BLUE_ORIGINAL_REGULAR'}) }}">Adopt an original blue elephpant</a><br />
     <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herd_id, 'breed': 'BLACK_AMSTERDAMPHP_REGULAR'}) }}">Adopt an amsterdamPHP elephpant</a><br />
     <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herd_id, 'breed': 'WHITE_CONFOO_LARGE'}) }}">Adopt a ConFoo elephpant</a><br />

--- a/src/Elewant/FrontendBundle/Resources/views/Example/top5.html.twig
+++ b/src/Elewant/FrontendBundle/Resources/views/Example/top5.html.twig
@@ -1,0 +1,15 @@
+{% extends 'ElewantFrontendBundle::layout.html.twig' %}
+
+{% block body %}
+    <p><a href="{{ path('herd_list') }}">Back to herd list</a></p>
+
+    <p>Last 5 formed Herds</p>
+    {% for herd in herds %}
+        <a href="{{ path('herd_show', {'herdId': herd.herd_id}) }}">{{ herd.name }} {{ herd.formed_on }}</a><br />
+    {% endfor %}
+
+    <p>Last 5 adopted ElePHPants</p>
+    {% for elephpant in elephpants %}
+        <a href="{{ path('herd_show', {'herdId': elephpant.herd_id}) }}">{{ elephpant.breed }} {{ elephpant.adopted_on }}</a><br />
+    {% endfor %}
+{% endblock %}

--- a/src/Elewant/Herding/Projections/HerdListing.php
+++ b/src/Elewant/Herding/Projections/HerdListing.php
@@ -56,4 +56,27 @@ final class HerdListing
         return $qb->execute()->fetch();
     }
 
+    public function lastNewHerds(int $limit)
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('*')
+            ->from(HerdProjector::TABLE_HERD)
+            ->orderBy('formed_on', 'DESC')
+            ->setMaxResults($limit);
+
+        return $qb->execute()->fetchAll();
+    }
+
+    public function lastNewElePHPants(int $limit)
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('*')
+            ->from(HerdProjector::TABLE_ELEPHPANT)
+            ->orderBy('adopted_on', 'DESC')
+            ->setMaxResults($limit);
+
+        return $qb->execute()->fetchAll();
+    }
+
+
 }


### PR DESCRIPTION
This PR adds a `last 5 formed herds` and `last 5 adopted elephpants` view to the example.
Probably throw-away.