### PR TITLE
Replace DBAL readmodel with ORM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ cache:
 
 install:
   - cp app/config/parameters.yml.dist app/config/parameters.yml
+  - mysql -e "create database elewant;"
+  - mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'elewant'@'localhost'"
   - composer install
 
 before_script:

--- a/app/DoctrineMigrations/Version20170805082923.php
+++ b/app/DoctrineMigrations/Version20170805082923.php
@@ -15,8 +15,8 @@ class Version20170805082923 extends AbstractMigration
     {
         $herd = $schema->createTable(HerdProjector::TABLE_HERD);
 
-        $herd->addColumn('herd_id', 'string', ['length' => 36]);
-        $herd->addColumn('shepherd_id', 'string', ['length' => 36]);
+        $herd->addColumn('herd_id', 'guid');
+        $herd->addColumn('shepherd_id', 'guid');
         $herd->addColumn('name', 'string', ['length' => 64]);
         $herd->addColumn('formed_on', 'datetime');
         $herd->setPrimaryKey(['herd_id']);
@@ -25,12 +25,12 @@ class Version20170805082923 extends AbstractMigration
 
         $elephpant = $schema->createTable(HerdProjector::TABLE_ELEPHPANT);
 
-        $elephpant->addColumn('elephpant_id', 'string', ['length' => 36]);
-        $elephpant->addColumn('herd_id', 'string', ['length' => 36]);
-        $elephpant->addColumn('breed', 'string', ['length' => 64]);
+        $elephpant->addColumn('elephpant_id', 'guid');
+        $elephpant->addColumn('herd_id', 'guid');
+        $elephpant->addColumn('breed', 'breed', ['length' => 64]);
         $elephpant->addColumn('adopted_on', 'datetime');
         $elephpant->setPrimaryKey(['elephpant_id']);
-        $elephpant->addIndex(['herd_id']);
+        $elephpant->addForeignKeyConstraint(HerdProjector::TABLE_HERD,['herd_id'], ['herd_id']);
         $elephpant->addIndex(['adopted_on']);
     }
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -53,10 +53,17 @@ doctrine:
         user: "%database_user%"
         password: "%database_password%"
         charset: utf8mb4
+        default_table_options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
+        types:
+            breed:
+                class: Elewant\FrontendBundle\Entity\CustomType\Breed
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"
         naming_strategy: doctrine.orm.naming_strategy.underscore
         auto_mapping: true
+
 
 # Swiftmailer Configuration
 swiftmailer:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,10 +1,10 @@
 parameters:
-    database_host:     "127.0.0.1"
+
+    database_host:     ~
     database_port:     ~
+    database_unix_socket: /var/run/mysqld/mysqld.sock
     database_name:     "elewant"
     database_user:     "elewant"
-    database_password: "elewant"
-    database_unix_socket: /var/run/mysqld/mysqld.sock
     database_password: ~
 
     mailer_transport:  "smtp"

--- a/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
+++ b/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Elewant\FrontendBundle\Controller;
 
+use Elewant\FrontendBundle\Repository\HerdRepository;
 use Elewant\Herding\Model\Commands\AbandonElePHPant;
 use Elewant\Herding\Model\Commands\AbandonHerd;
 use Elewant\Herding\Model\Commands\AdoptElePHPant;
 use Elewant\Herding\Model\Commands\FormHerd;
-use Elewant\Herding\Projections\HerdListing;
 use Prooph\ServiceBus\CommandBus;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -32,10 +32,10 @@ class HerdingExampleController extends Controller
             return $this->redirectToRoute('root');
         }
 
-        /** @var HerdListing $herdListing */
-        $herdListing = $this->container->get('elewant.herd_projection.herd_listing');
+        /** @var HerdRepository $herdRepository */
+        $herdRepository = $this->get('elewant.herd.herd_repository');
 
-        $herds = $herdListing->findAll();
+        $herds = $herdRepository->findAll();
 
         return $this->render('ElewantFrontendBundle:Example:herd_list.html.twig', ['herds' => $herds]);
     }
@@ -69,13 +69,15 @@ class HerdingExampleController extends Controller
             return $this->redirectToRoute('root');
         }
 
-        /** @var HerdListing $herdListing */
-        $herdListing = $this->container->get('elewant.herd_projection.herd_listing');
+        /** @var HerdRepository $herdRepository */
+        $herdRepository = $this->get('elewant.herd.herd_repository');
 
-        $herds = $herdListing->lastNewHerds(5);
-        $elePHPants = $herdListing->lastNewElePHPants(5);
+        $data = [
+            'newest_herds' => $herdRepository->lastNewHerds(5),
+            'newest_elephpants' => $herdRepository->lastNewElePHPants(5),
+        ];
 
-        return $this->render('ElewantFrontendBundle:Example:top5.html.twig', ['herds' => $herds, 'elephpants' => $elePHPants]);
+        return $this->render('ElewantFrontendBundle:Example:top5.html.twig', $data);
     }
 
     /**
@@ -87,15 +89,13 @@ class HerdingExampleController extends Controller
             return $this->redirectToRoute('root');
         }
 
-        /** @var HerdListing $herdListing */
-        $herdListing = $this->container->get('elewant.herd_projection.herd_listing');
+        /** @var HerdRepository $herdRepository */
+        $herdRepository = $this->get('elewant.herd.herd_repository');
 
-        $herd       = $herdListing->findById($herdId);
-        $elephpants = $herdListing->findElephpantsByHerdId($herdId);
+        $herd       = $herdRepository->find($herdId);
 
         $data = [
-            'herd'       => $herd,
-            'elephpants' => $elephpants,
+            'herd'       => $herd
         ];
 
         return $this->render('ElewantFrontendBundle:Example:herd_show.html.twig', $data);

--- a/src/Elewant/FrontendBundle/ElewantFrontendBundle.php
+++ b/src/Elewant/FrontendBundle/ElewantFrontendBundle.php
@@ -4,21 +4,8 @@ declare(strict_types=1);
 
 namespace Elewant\FrontendBundle;
 
-use Doctrine\DBAL\Types\Type;
-use Elewant\FrontendBundle\Entity\CustomType\Breed;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ElewantFrontendBundle extends Bundle
 {
-
-    public function boot()
-    {
-        /**
-         * This is probably not the place to put a custom Doctrine type...
-         * (no need to look at git blame: it was me: @f_u_e_n_t_e)
-         */
-        if (!Type::hasType('breed')) {
-            Type::addType('breed', Breed::class);
-        }
-    }
 }

--- a/src/Elewant/FrontendBundle/ElewantFrontendBundle.php
+++ b/src/Elewant/FrontendBundle/ElewantFrontendBundle.php
@@ -17,6 +17,8 @@ class ElewantFrontendBundle extends Bundle
          * This is probably not the place to put a custom Doctrine type...
          * (no need to look at git blame: it was me: @f_u_e_n_t_e)
          */
-        Type::addType('breed', Breed::class);
+        if (!Type::hasType('breed')) {
+            Type::addType('breed', Breed::class);
+        }
     }
 }

--- a/src/Elewant/FrontendBundle/ElewantFrontendBundle.php
+++ b/src/Elewant/FrontendBundle/ElewantFrontendBundle.php
@@ -4,8 +4,19 @@ declare(strict_types=1);
 
 namespace Elewant\FrontendBundle;
 
+use Doctrine\DBAL\Types\Type;
+use Elewant\FrontendBundle\Entity\CustomType\Breed;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ElewantFrontendBundle extends Bundle
 {
+
+    public function boot()
+    {
+        /**
+         * This is probably not the place to put a custom Doctrine type...
+         * (no need to look at git blame: it was me: @f_u_e_n_t_e)
+         */
+        Type::addType('breed', Breed::class);
+    }
 }

--- a/src/Elewant/FrontendBundle/Entity/Connection.php
+++ b/src/Elewant/FrontendBundle/Entity/Connection.php
@@ -8,10 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- * @ORM\Table(
- *     options={"charset"="utf8mb4", "collate"="utf8mb4_unicode_ci"},
- *     indexes={@ORM\Index(name="resource_idx", columns={"resource", "resource_id"})}
- * )
+ * @ORM\Table(indexes={@ORM\Index(name="resource_idx", columns={"resource", "resource_id"})})
  *
  * We cannot use `final` here, because of Doctrine proxies.
  */

--- a/src/Elewant/FrontendBundle/Entity/CustomType/Breed.php
+++ b/src/Elewant/FrontendBundle/Entity/CustomType/Breed.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\FrontendBundle\Entity\CustomType;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use Elewant\Herding\Model\Breed as BreedType;
+
+final class Breed extends Type
+{
+    const NAME = 'breed';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return BreedType::fromString($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        /** @var BreedType $value */
+        $value->toString();
+    }
+}

--- a/src/Elewant/FrontendBundle/Entity/Elephpant.php
+++ b/src/Elewant/FrontendBundle/Entity/Elephpant.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\FrontendBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Elewant\Herding\Model\Breed;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="elephpant")
+ */
+class Elephpant
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="Elewant\FrontendBundle\Entity\Herd", inversedBy="elephpants")
+     * @ORM\JoinColumn(name="herd_id", referencedColumnName="herd_id", nullable=false)
+     * @var Herd
+     */
+    private $herd;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="guid")
+     * @var string
+     */
+    private $herdId;
+
+    /**
+     * @ORM\Column(type="breed")
+     * @var Breed
+     */
+    private $breed;
+
+    /**
+     * @ORM\Column(type="datetime")
+     * @var \DateTime
+     */
+    private $adoptedOn;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="guid")
+     * @var string
+     */
+    private $elephpantId;
+
+    public function herd(): Herd
+    {
+        return $this->herd;
+    }
+
+    public function breed(): Breed
+    {
+        return $this->breed;
+    }
+
+    public function adoptedOn(): \Datetime
+    {
+        return $this->adoptedOn;
+    }
+
+    public function elePHPantId(): string
+    {
+        return $this->elephpantId;
+    }
+
+    public function getHerdId() : string
+    {
+        return $this->herdId;
+    }
+}
+

--- a/src/Elewant/FrontendBundle/Entity/Elephpant.php
+++ b/src/Elewant/FrontendBundle/Entity/Elephpant.php
@@ -9,7 +9,7 @@ use Elewant\Herding\Model\Breed;
 
 /**
  * @ORM\Entity
- * @ORM\Table(name="elephpant")
+ * @ORM\Table(indexes={@ORM\Index(columns={"adopted_on"})})
  */
 class Elephpant
 {
@@ -21,14 +21,7 @@ class Elephpant
     private $herd;
 
     /**
-     * @ORM\Id
-     * @ORM\Column(type="guid")
-     * @var string
-     */
-    private $herdId;
-
-    /**
-     * @ORM\Column(type="breed")
+     * @ORM\Column(type="breed", length=64)
      * @var Breed
      */
     private $breed;
@@ -41,6 +34,7 @@ class Elephpant
 
     /**
      * @ORM\Id
+     * @ORM\GeneratedValue(strategy="NONE")
      * @ORM\Column(type="guid")
      * @var string
      */
@@ -64,11 +58,6 @@ class Elephpant
     public function elePHPantId(): string
     {
         return $this->elephpantId;
-    }
-
-    public function getHerdId() : string
-    {
-        return $this->herdId;
     }
 }
 

--- a/src/Elewant/FrontendBundle/Entity/Herd.php
+++ b/src/Elewant/FrontendBundle/Entity/Herd.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * Herd
  * @ORM\Entity(repositoryClass="Elewant\FrontendBundle\Repository\HerdRepository")
- * @ORM\Table(options={"charset"="utf8mb4", "collate"="utf8mb4_unicode_ci"})
+ * @ORM\Table(indexes={@ORM\Index(columns={"formed_on"}),@ORM\Index(columns={"shepherd_id"})})
  */
 class Herd
 {
@@ -35,6 +35,7 @@ class Herd
 
     /**
      * @ORM\Id
+     * @ORM\GeneratedValue(strategy="NONE")
      * @ORM\Column(type="guid")
      * @var string
      */

--- a/src/Elewant/FrontendBundle/Entity/Herd.php
+++ b/src/Elewant/FrontendBundle/Entity/Herd.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\FrontendBundle\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Herd
+ * @ORM\Entity(repositoryClass="Elewant\FrontendBundle\Repository\HerdRepository")
+ * @ORM\Table(options={"charset"="utf8mb4", "collate"="utf8mb4_unicode_ci"})
+ */
+class Herd
+{
+    /**
+     * @ORM\Column(type="guid")
+     * @var string
+     */
+    private $shepherdId;
+
+    /**
+     * @ORM\Column(type="string", length=64)
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @ORM\Column(type="datetime")
+     * @var \DateTime
+     */
+    private $formedOn;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="guid")
+     * @var string
+     */
+    private $herdId;
+
+    /**
+     * @ORM\OneToMany(targetEntity="Elewant\FrontendBundle\Entity\Elephpant", mappedBy="herd", cascade={"persist"})
+     * @var ArrayCollection
+     */
+    private $elephpants;
+
+    private function __construct()
+    {
+        $this->elephpants = new ArrayCollection();
+    }
+
+    public function shepherdId(): string
+    {
+        return $this->shepherdId;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function formedOn(): \Datetime
+    {
+        return $this->formedOn;
+    }
+
+    public function herdId(): string
+    {
+        return $this->herdId;
+    }
+
+    public function elePHPants(): Collection
+    {
+        return $this->elephpants;
+    }
+
+}
+

--- a/src/Elewant/FrontendBundle/Entity/User.php
+++ b/src/Elewant/FrontendBundle/Entity/User.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity(repositoryClass="Elewant\FrontendBundle\Repository\UserRepository")
- * @ORM\Table(options={"charset"="utf8mb4", "collate"="utf8mb4_unicode_ci"})
+ * @ORM\Table
  * @UniqueEntity("username")
  *
  * We cannot use `final` here, because of Doctrine proxies.

--- a/src/Elewant/FrontendBundle/Repository/HerdRepository.php
+++ b/src/Elewant/FrontendBundle/Repository/HerdRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\FrontendBundle\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Elewant\FrontendBundle\Entity\Elephpant;
+use Elewant\FrontendBundle\Entity\Herd;
+
+final class HerdRepository extends EntityRepository
+{
+
+    /**
+     * @param int $limit
+     *
+     * @return Herd[]
+     */
+    public function lastNewHerds(int $limit): array
+    {
+        $dql = <<<EOQ
+SELECT h
+FROM ElewantFrontendBundle:Herd h
+ORDER BY h.formedOn DESC
+EOQ;
+        $query = $this->getEntityManager()->createQuery($dql);
+        $query->setMaxResults($limit);
+
+        return $query->getResult();
+    }
+
+    /**
+     * @param int $limit
+     *
+     * @return Elephpant[]
+     */
+    public function lastNewElePHPants(int $limit): array
+    {
+        $dql = <<<EOQ
+SELECT e
+FROM ElewantFrontendBundle:Elephpant e
+ORDER BY e.adoptedOn DESC
+EOQ;
+
+        $query = $this->getEntityManager()->createQuery($dql);
+        $query->setMaxResults($limit);
+
+        return $query->getResult();
+    }
+
+
+}

--- a/src/Elewant/FrontendBundle/Resources/config/services.yml
+++ b/src/Elewant/FrontendBundle/Resources/config/services.yml
@@ -20,6 +20,11 @@ services:
 
     # Elewant - Herding
 
+    elewant.herd.herd_repository:
+        class: Elewant\FrontendBundle\Repository\HerdRepository
+        factory: [ "@doctrine.orm.entity_manager", getRepository ]
+        arguments: [ Elewant\FrontendBundle\Entity\Herd ]
+
     elewant.api_command_controller:
         class: Elewant\FrontendBundle\Controller\ApiCommandController
         arguments: ['@prooph_service_bus.herding_command_bus', '@prooph_service_bus.message_factory']

--- a/src/Elewant/FrontendBundle/Resources/views/Example/herd_list.html.twig
+++ b/src/Elewant/FrontendBundle/Resources/views/Example/herd_list.html.twig
@@ -5,8 +5,8 @@
 
     <p>
     {% for herd in herds %}
-        <a href="{{ path('herd_show', {'herdId': herd.herd_id}) }}">{{ herd.name }}</a>
-        <a href="{{ path('herd_abandon', {'herdId': herd.herd_id}) }}">(abandon)</a><br />
+        <a href="{{ path('herd_show', {'herdId': herd.herdId}) }}">{{ herd.name }}</a>
+        <a href="{{ path('herd_abandon', {'herdId': herd.herdId}) }}">(abandon)</a><br />
     {% endfor %}
     </p>
 

--- a/src/Elewant/FrontendBundle/Resources/views/Example/herd_show.html.twig
+++ b/src/Elewant/FrontendBundle/Resources/views/Example/herd_show.html.twig
@@ -6,17 +6,17 @@
     <p>
     <ul>
         <li>Name: {{ herd.name }}</li>
-        <li>HerdId: {{ herd.herd_id }}</li>
-        <li>ShepherdId: {{ herd.shepherd_id }}</li>
-        <li>Formed on: {{ herd.formed_on }}</li>
+        <li>HerdId: {{ herd.herdId }}</li>
+        <li>ShepherdId: {{ herd.shepherdId }}</li>
+        <li>Formed on: {{ herd.formedOn|date('Y-m-d H:i') }}</li>
     </ul>
     </p>
     
-    <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herd_id, 'breed': 'BLUE_ORIGINAL_REGULAR'}) }}">Adopt an original blue elephpant</a><br />
-    <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herd_id, 'breed': 'BLACK_AMSTERDAMPHP_REGULAR'}) }}">Adopt an amsterdamPHP elephpant</a><br />
-    <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herd_id, 'breed': 'WHITE_CONFOO_LARGE'}) }}">Adopt a ConFoo elephpant</a><br />
+    <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herdId, 'breed': 'BLUE_ORIGINAL_REGULAR'}) }}">Adopt an original blue elephpant</a><br />
+    <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herdId, 'breed': 'BLACK_AMSTERDAMPHP_REGULAR'}) }}">Adopt an amsterdamPHP elephpant</a><br />
+    <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herdId, 'breed': 'WHITE_CONFOO_LARGE'}) }}">Adopt a ConFoo elephpant</a><br />
 
-    {% for elephpant in elephpants %}
-        {{ elephpant.breed }}<a href="{{ path('herd_abandon_elephpant', {'herdId': herd.herd_id, 'breed': elephpant.breed}) }}">(abandon)</a></br >
+    {% for elephpant in herd.elephpants %}
+        {{ elephpant.breed }}<a href="{{ path('herd_abandon_elephpant', {'herdId': herd.herdId, 'breed': elephpant.breed}) }}">(abandon)</a></br >
     {% endfor %}
 {% endblock %}

--- a/src/Elewant/FrontendBundle/Resources/views/Example/top5.html.twig
+++ b/src/Elewant/FrontendBundle/Resources/views/Example/top5.html.twig
@@ -3,13 +3,17 @@
 {% block body %}
     <p><a href="{{ path('herd_list') }}">Back to herd list</a></p>
 
-    <p>Last 5 formed Herds</p>
-    {% for herd in herds %}
-        <a href="{{ path('herd_show', {'herdId': herd.herd_id}) }}">{{ herd.name }} {{ herd.formed_on }}</a><br />
+    <h4>Last 5 formed Herds</h4>
+    <p>
+    {% for herd in newest_herds %}
+        <a href="{{ path('herd_show', {'herdId': herd.herdId}) }}">{{ herd.name }} {{ herd.formedOn|date('Y-m-d H:i:s') }}</a><br />
     {% endfor %}
+    </p>
 
-    <p>Last 5 adopted ElePHPants</p>
-    {% for elephpant in elephpants %}
-        <a href="{{ path('herd_show', {'herdId': elephpant.herd_id}) }}">{{ elephpant.breed }} {{ elephpant.adopted_on }}</a><br />
+    <h4>Latest adopted ElePHPants</h4>
+    <p>
+    {% for elephpant in newest_elephpants %}
+        <a href="{{ path('herd_show', {'herdId': elephpant.herd.herdId}) }}">{{ elephpant.herd.name }} {{ elephpant.breed }} {{ elephpant.adoptedOn|date('Y-m-d H:i') }}</a><br />
     {% endfor %}
+    </p>
 {% endblock %}

--- a/src/Elewant/Herding/Projections/HerdListing.php
+++ b/src/Elewant/Herding/Projections/HerdListing.php
@@ -6,6 +6,12 @@ namespace Elewant\Herding\Projections;
 
 use Doctrine\DBAL\Connection;
 
+/**
+ * Class HerdListing
+ *
+ * This class is used for simple queries against the herd projection, in order to test the outcome
+ * of a command in end-to-end tests. It should _not_ be used in the FrontendBundle anywhere else.
+ */
 final class HerdListing
 {
     /**
@@ -55,28 +61,5 @@ final class HerdListing
 
         return $qb->execute()->fetch();
     }
-
-    public function lastNewHerds(int $limit)
-    {
-        $qb = $this->connection->createQueryBuilder();
-        $qb->select('*')
-            ->from(HerdProjector::TABLE_HERD)
-            ->orderBy('formed_on', 'DESC')
-            ->setMaxResults($limit);
-
-        return $qb->execute()->fetchAll();
-    }
-
-    public function lastNewElePHPants(int $limit)
-    {
-        $qb = $this->connection->createQueryBuilder();
-        $qb->select('*')
-            ->from(HerdProjector::TABLE_ELEPHPANT)
-            ->orderBy('adopted_on', 'DESC')
-            ->setMaxResults($limit);
-
-        return $qb->execute()->fetchAll();
-    }
-
 
 }

--- a/src/Elewant/Herding/Projections/HerdProjector.php
+++ b/src/Elewant/Herding/Projections/HerdProjector.php
@@ -81,7 +81,11 @@ final class HerdProjector
 
     public function clearAllTables()
     {
-        $this->connection->executeUpdate(sprintf('truncate table %s', self::TABLE_ELEPHPANT));
-        $this->connection->executeUpdate(sprintf('truncate table %s', self::TABLE_HERD));
+        $platform = $this->connection->getDatabasePlatform();
+
+        $this->connection->query('SET FOREIGN_KEY_CHECKS=0');
+        $this->connection->executeUpdate($platform->getTruncateTableSQL(self::TABLE_HERD));
+        $this->connection->executeUpdate($platform->getTruncateTableSQL(self::TABLE_ELEPHPANT));
+        $this->connection->query('SET FOREIGN_KEY_CHECKS=1');
     }
 }


### PR DESCRIPTION
This PR introduces an ORM-based readmodel for a `Herd`. A few things to note:

The Elephpant entity is _not_ called ElePHPant (note the capitals) because I am to stupid to figure out how to configure it properly... do we want to change that?

I have added a `boot()` method to the bundle to add a custom type based on the concept `Breed` form the domain. Is that the correct place to add custom types, or is there a magic incantation that I can use in the DI configuration?

The custom type above actually uses the `Breed` value object from the `Herding` domain. Is that considered ok? I'm not sure we need it... 
In the same vain: the `herdId()` and `elephpantId()` return strings now, but could also return the `HerdId` and `ElePHPantId from the domain... I have not done that because I think we'll be doing a lot of useless conversions, the views work with strings and the commands also. So there is no place outside of the domain where these Id's actually make sense... but I'm not completely sure.