### PR TITLE
Change /example to be more in line with the proposed application

### DIFF
--- a/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
+++ b/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
@@ -13,6 +13,7 @@ use Elewant\Herding\Model\Commands\FormHerd;
 use Prooph\ServiceBus\CommandBus;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @Route("/example")
@@ -20,9 +21,32 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class HerdingExampleController extends Controller
 {
     private $shepherdId = '00000000-0000-0000-0000-000000000000';
-    private $herdNameSeed = ['honey','rob','delight','change','merciful','achiever','match','quick','spare',
-                             'chubby','grain','frame','division','nose','reply','icicle','improve','wool','amusing',
-                             'meek','substantial','bee','earn','word'];
+    private $herdNameSeed = [
+        'honey',
+        'rob',
+        'delight',
+        'change',
+        'merciful',
+        'achiever',
+        'match',
+        'quick',
+        'spare',
+        'chubby',
+        'grain',
+        'frame',
+        'division',
+        'nose',
+        'reply',
+        'icicle',
+        'improve',
+        'wool',
+        'amusing',
+        'meek',
+        'substantial',
+        'bee',
+        'earn',
+        'word',
+    ];
 
     /**
      * @Route("/", name="herd_list")
@@ -74,11 +98,35 @@ class HerdingExampleController extends Controller
         $herdRepository = $this->get('elewant.herd.herd_repository');
 
         $data = [
-            'newest_herds' => $herdRepository->lastNewHerds(5),
+            'newest_herds'      => $herdRepository->lastNewHerds(5),
             'newest_elephpants' => $herdRepository->lastNewElePHPants(5),
         ];
 
         return $this->render('ElewantFrontendBundle:Example:top5.html.twig', $data);
+    }
+
+    /**
+     * @Route("/search", name="herd_search")
+     */
+    public function searchAction(Request $request)
+    {
+        if ($this->accessNotAllowed()) {
+            return $this->redirectToRoute('root');
+        }
+
+        $data = [
+            'search' => $request->query->get('q'),
+            'matches'    => [],
+        ];
+
+        if ($request->query->get('q')) {
+            /** @var HerdRepository $herdRepository */
+            $herdRepository = $this->get('elewant.herd.herd_repository');
+
+            $data['matches'] = $herdRepository->search($request->query->get('q'));
+        }
+
+        return $this->render('ElewantFrontendBundle:Example:search.html.twig', $data);
     }
 
     /**
@@ -93,11 +141,11 @@ class HerdingExampleController extends Controller
         /** @var HerdRepository $herdRepository */
         $herdRepository = $this->get('elewant.herd.herd_repository');
 
-        $herd       = $herdRepository->find($herdId);
+        $herd = $herdRepository->find($herdId);
 
         $data = [
-            'herd'       => $herd,
-            'breeds'     => Breed::availableTypes(),
+            'herd'   => $herd,
+            'breeds' => Breed::availableTypes(),
         ];
 
         if (count($herd->elephpants()) === 0) {
@@ -161,7 +209,8 @@ class HerdingExampleController extends Controller
         return $this->redirectToRoute('herd_list');
     }
 
-    private function accessNotAllowed() {
+    private function accessNotAllowed()
+    {
         return !$this->get('kernel')->isDebug();
     }
 }

--- a/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
+++ b/src/Elewant/FrontendBundle/Controller/HerdingExampleController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Elewant\FrontendBundle\Controller;
 
 use Elewant\FrontendBundle\Repository\HerdRepository;
+use Elewant\Herding\Model\Breed;
 use Elewant\Herding\Model\Commands\AbandonElePHPant;
 use Elewant\Herding\Model\Commands\AbandonHerd;
 use Elewant\Herding\Model\Commands\AdoptElePHPant;
@@ -95,10 +96,15 @@ class HerdingExampleController extends Controller
         $herd       = $herdRepository->find($herdId);
 
         $data = [
-            'herd'       => $herd
+            'herd'       => $herd,
+            'breeds'     => Breed::availableTypes(),
         ];
 
-        return $this->render('ElewantFrontendBundle:Example:herd_show.html.twig', $data);
+        if (count($herd->elephpants()) === 0) {
+            return $this->render('ElewantFrontendBundle:Example:herd_form.html.twig', $data);
+        } else {
+            return $this->render('ElewantFrontendBundle:Example:herd_show.html.twig', $data);
+        }
     }
 
     /**

--- a/src/Elewant/FrontendBundle/Entity/Herd.php
+++ b/src/Elewant/FrontendBundle/Entity/Herd.php
@@ -77,5 +77,20 @@ class Herd
         return $this->elephpants;
     }
 
+    public function elePHPantBreedCounts(): Collection
+    {
+        $result = [];
+        foreach ($this->elephpants as $elephpant) {
+            $breed = $elephpant->breed()->toString();
+            if (!isset($result[$breed])) {
+                $result[$breed] = 0;
+            }
+            $result[$breed]++;
+        }
+
+        return new ArrayCollection($result);
+    }
+
+
 }
 

--- a/src/Elewant/FrontendBundle/Repository/HerdRepository.php
+++ b/src/Elewant/FrontendBundle/Repository/HerdRepository.php
@@ -48,5 +48,24 @@ EOQ;
         return $query->getResult();
     }
 
+    /**
+     * @param string $searchString
+     *
+     * @return Herd[]
+     */
+    public function search(string $searchString): array
+    {
+        $dql = <<<EOQ
+SELECT h
+FROM ElewantFrontendBundle:Herd h
+WHERE h.name LIKE :searchString
+ORDER BY h.formedOn DESC
+EOQ;
+
+        $query = $this->getEntityManager()->createQuery($dql);
+        $query->setParameter('searchString', '%' . $searchString . '%');
+
+        return $query->getResult();
+    }
 
 }

--- a/src/Elewant/FrontendBundle/Repository/HerdRepository.php
+++ b/src/Elewant/FrontendBundle/Repository/HerdRepository.php
@@ -16,9 +16,9 @@ final class HerdRepository extends EntityRepository
      *
      * @return Herd[]
      */
-    public function lastNewHerds(int $limit): array
+    public function lastNewHerds(int $limit) : array
     {
-        $dql = <<<EOQ
+        $dql   = <<<EOQ
 SELECT h
 FROM ElewantFrontendBundle:Herd h
 ORDER BY h.formedOn DESC
@@ -34,7 +34,7 @@ EOQ;
      *
      * @return Elephpant[]
      */
-    public function lastNewElePHPants(int $limit): array
+    public function lastNewElePHPants(int $limit) : array
     {
         $dql = <<<EOQ
 SELECT e

--- a/src/Elewant/FrontendBundle/Resources/views/Example/herd_form.html.twig
+++ b/src/Elewant/FrontendBundle/Resources/views/Example/herd_form.html.twig
@@ -1,0 +1,32 @@
+{% extends 'ElewantFrontendBundle::layout.html.twig' %}
+
+{% block body %}
+    <p><a href="{{ path('herd_list') }}">Back to herd list</a></p>
+
+    <p>
+    {% for breed in breeds %}
+        <a href="#" onclick="abandon('{{ breed }}')">-</a> {{ breed }}: <span id="{{ breed }}_COUNT">0</span> <a href="#" onclick="adopt('{{ breed }}')">+</a></br >
+    {% endfor %}
+    </p>
+
+    <script>
+        function adopt(breed)
+        {
+            var xmlHttp = new XMLHttpRequest();
+            xmlHttp.open( "GET", '/example/{{ herd.herdId }}/adopt/' + breed );
+            xmlHttp.send( null );
+            var counter = document.getElementById(breed + '_COUNT');
+            counter.innerHTML = parseInt(counter.innerHTML) + 1;
+        }
+        function abandon(breed)
+        {
+            var xmlHttp = new XMLHttpRequest();
+            xmlHttp.open( "GET", '/example/{{ herd.herdId }}/abandon/' + breed );
+            xmlHttp.send( null );
+            var counter = document.getElementById(breed + '_COUNT');
+            counter.innerHTML = parseInt(counter.innerHTML) - 1;
+        }
+
+    </script>
+
+{% endblock %}

--- a/src/Elewant/FrontendBundle/Resources/views/Example/herd_show.html.twig
+++ b/src/Elewant/FrontendBundle/Resources/views/Example/herd_show.html.twig
@@ -11,12 +11,25 @@
         <li>Formed on: {{ herd.formedOn|date('Y-m-d H:i') }}</li>
     </ul>
     </p>
-    
-    <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herdId, 'breed': 'BLUE_ORIGINAL_REGULAR'}) }}">Adopt an original blue elephpant</a><br />
-    <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herdId, 'breed': 'BLACK_AMSTERDAMPHP_REGULAR'}) }}">Adopt an amsterdamPHP elephpant</a><br />
-    <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herdId, 'breed': 'WHITE_CONFOO_LARGE'}) }}">Adopt a ConFoo elephpant</a><br />
 
-    {% for elephpant in herd.elephpants %}
-        {{ elephpant.breed }}<a href="{{ path('herd_abandon_elephpant', {'herdId': herd.herdId, 'breed': elephpant.breed}) }}">(abandon)</a></br >
+
+    <p>
+    <select name="breedChoice" id="breedChoice">
+    {% for breed in breeds %} }}
+        <option value="{{ breed }}">{{ breed }}</option>
+    {% endfor %}
+    </select>
+    <button id="adoptivate">Adopt</button>
+    </p>
+    <script type="text/javascript">
+        var button = document.getElementById('adoptivate');
+        button.onclick = function() {
+            var breed = document.getElementById('breedChoice');
+            document.location = '/example/{{ herd.herdId }}/adopt/' + breed.options[ breed.selectedIndex ].value;
+        };
+    </script>
+
+    {% for breed, count in herd.elePHPantBreedCounts %}
+    <a href="{{ path('herd_abandon_elephpant', {'herdId': herd.herdId, 'breed': breed}) }}">-</a> {{ breed }}: {{ count }} <a href="{{ path('herd_adopt_elephpant', {'herdId': herd.herdId, 'breed': breed}) }}">+</a></br >
     {% endfor %}
 {% endblock %}

--- a/src/Elewant/FrontendBundle/Resources/views/Example/search.html.twig
+++ b/src/Elewant/FrontendBundle/Resources/views/Example/search.html.twig
@@ -1,15 +1,18 @@
 {% extends 'ElewantFrontendBundle::layout.html.twig' %}
 
 {% block body %}
-    <p><a href="{{ path('herd_top_5') }}">View top5 lists</a></p>
+    <p><a href="{{ path('herd_list') }}">Back to herd list</a></p>
+
+    <form method="get" action="">
+        <input type="text" name="q" value="{{ search }}">
+        <input type="submit" name="search" value="Search">
+    </form>
 
     <p>
-    {% for herd in herds %}
+    {% for herd in matches %}
         <a href="{{ path('herd_show', {'herdId': herd.herdId}) }}">{{ herd.name }}</a>
         <a href="{{ path('herd_abandon', {'herdId': herd.herdId}) }}">(abandon)</a><br />
     {% endfor %}
     </p>
-    <p><a href="{{ path('herd_search') }}">Search herds</a></p>
 
-    <p><a href="{{ path('herd_form') }}">Form a new herd</a></p>
 {% endblock %}

--- a/src/Elewant/Herding/Model/Breed.php
+++ b/src/Elewant/Herding/Model/Breed.php
@@ -72,12 +72,18 @@ class Breed
         $this->type = $type;
     }
 
-    public static function fromString(string $type): self
-    {
+    public static function availableTypes() {
         $reflected = new ReflectionClass(self::class);
         $validTypes = $reflected->getConstants();
+        sort($validTypes);
 
-        if (!in_array($type, $validTypes)) {
+        return $validTypes;
+    }
+
+
+    public static function fromString(string $type): self
+    {
+        if (!in_array($type, self::availableTypes())) {
             throw SorryThatIsAnInvalid::breed($type);
         }
 


### PR DESCRIPTION
This PR changes the ExampleController to be more in line with the actual application:

- When editing a new (empty) Herd, a list of _all_ breeds is shown with "+" and "-" to add and remove ElePHPants.
- When editing a Herd that already contains ElePHPant(s), a view is used that only shows the contains ElePHPants with "+" and "-" to add and remove. In order to _add_ a new ElePHPant breed to the Herd, a dropdown is shown for each breed.
- It also adds a (super simplistic) search example.

