### PR TITLE
Update bootstrap to v4-beta, add 2 missing dependencies, fix grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "bootstrap": "^4.0.0-alpha.6",
+    "bootstrap": "^4.0.0-beta",
     "font-awesome": "^4.7.0",
     "jquery": "^3.2.1",
     "jquery-easing": "0.0.1",
@@ -12,6 +12,7 @@
     "tether": "^1.4.0"
   },
   "devDependencies": {
+    "autoprefixer": "^7.1.2",
     "clean-css-cli": "^4.1.6",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.1.0",
@@ -19,6 +20,7 @@
     "grunt-exec": "^2.0.0",
     "load-grunt-tasks": "^3.5.2",
     "node-sass": "^4.5.3",
+    "popper.js": "^1.11.1",
     "postcss-cli": "^4.1.0",
     "uglify-js": "^3.0.24"
   },
@@ -29,7 +31,7 @@
   },
   "scripts": {
     "clean-css": "cleancss --skip-advanced --source-map --output web/build/css/elewant.min.css web/build/css/elewant.css",
-    "postcss": "postcss --config node_modules/bootstrap/grunt/postcss.js --replace web/build/css/*.css",
+    "postcss": "postcss --config node_modules/bootstrap/build/postcss.config.js --replace web/build/css/*.css",
     "sass": "node-sass --output-style expanded --source-map true --precision 6 src/Elewant/FrontendBundle/Resources/assets/scss/elewant.scss web/build/css/elewant.css",
     "uglify": "uglifyjs --compress warnings=false --mangle --comments '/^!/' --output web/build/js/elewant.min.js web/build/js/elewant.js"
   }


### PR DESCRIPTION
If you didn't encounter issues, that's because you've provisioned the vagrant box when Bootstrap was still at the alpha6 version. They've released the first beta version, which needs an update in how we build our assets. This PR fixes that.

My advise is to remove your `node_modules` folder and run `npm install` and `grunt` again (in the vagrant box).