### PR TITLE
Form a new herd for every registered user

### DIFF
--- a/src/Elewant/AppBundle/Entity/User.php
+++ b/src/Elewant/AppBundle/Entity/User.php
@@ -99,7 +99,7 @@ class User implements UserInterface, \Serializable
 
     public function shepherdId() : ShepherdId
     {
-        return $this->shepherdId();
+        return $this->shepherdId;
     }
 
     public function username() : string

--- a/src/Elewant/AppBundle/Event/UserHasRegistered.php
+++ b/src/Elewant/AppBundle/Event/UserHasRegistered.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\AppBundle\Event;
+
+use Elewant\AppBundle\Entity\User;
+use Symfony\Component\EventDispatcher\Event;
+
+final class UserHasRegistered extends Event
+{
+    const NAME = 'user.has.registered';
+
+    /** @var User */
+    protected $user;
+
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+    }
+
+    public function user()
+    {
+        return $this->user;
+    }
+}

--- a/src/Elewant/AppBundle/EventSubscriber/NewUserSubscriber.php
+++ b/src/Elewant/AppBundle/EventSubscriber/NewUserSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\AppBundle\EventSubscriber;
+
+use Elewant\AppBundle\Event\UserHasRegistered;
+use Elewant\AppBundle\Repository\HerdRepository;
+use Elewant\Herding\Model\Commands\FormHerd;
+use Prooph\ServiceBus\CommandBus;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class NewUserSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var CommandBus
+     */
+    private $commandBus;
+
+    /**
+     * @var HerdRepository
+     */
+    private $herdRepository;
+
+    public function __construct(HerdRepository $herdRepository, CommandBus $commandBus)
+    {
+        $this->commandBus = $commandBus;
+        $this->herdRepository = $herdRepository;
+    }
+
+    public static function getSubscribedEvents() : array
+    {
+        return [
+            UserHasRegistered::NAME => 'formNewHerdWhen',
+        ];
+    }
+
+    public function formNewHerdWhen(UserHasRegistered $event)
+    {
+        $user = $event->user();
+
+        if (!$this->herdRepository->findOneByShepherdId($user->shepherdId())) {
+            $command = FormHerd::forShepherd($user->shepherdId()->toString(), $user->username());
+            $this->commandBus->dispatch($command);
+        }
+    }
+
+}

--- a/src/Elewant/AppBundle/Repository/HerdRepository.php
+++ b/src/Elewant/AppBundle/Repository/HerdRepository.php
@@ -7,6 +7,7 @@ namespace Elewant\AppBundle\Repository;
 use Doctrine\ORM\EntityRepository;
 use Elewant\AppBundle\Entity\Elephpant;
 use Elewant\AppBundle\Entity\Herd;
+use Elewant\Herding\Model\ShepherdId;
 
 final class HerdRepository extends EntityRepository
 {
@@ -67,4 +68,19 @@ EOQ;
 
         return $query->getResult();
     }
+
+    public function findOneByShepherdId(ShepherdId $shepherdId) :? Herd
+    {
+        $dql   = <<<EOQ
+SELECT h
+FROM ElewantAppBundle:Herd h
+WHERE h.shepherdId = :shepherdId
+EOQ;
+        $query = $this->getEntityManager()->createQuery($dql);
+        $query->setParameter('shepherdId', $shepherdId->toString());
+
+        return $query->getSingleResult();
+
+    }
+
 }

--- a/src/Elewant/AppBundle/Resources/config/services.yml
+++ b/src/Elewant/AppBundle/Resources/config/services.yml
@@ -1,10 +1,10 @@
 services:
 
-    # Elewant - Frontend
+    # Elewant - App
 
     elewant.security.user_provider:
         class: Elewant\AppBundle\Security\UserProvider
-        arguments: [ "@doctrine" ]
+        arguments: [ "@doctrine", "@event_dispatcher" ]
 
     elewant.security.registration.form:
         class: Elewant\AppBundle\Form\UserType
@@ -17,6 +17,12 @@ services:
 
     elewant.security.account.connector:
         alias: elewant.security.user_provider
+
+    elewant.event_subscriber.new_user:
+        class: Elewant\AppBundle\EventSubscriber\NewUserSubscriber
+        arguments: ["@elewant.herd.herd_repository", "@prooph_service_bus.herding_command_bus"]
+        tags:
+            - { name: kernel.event_subscriber }
 
     # Elewant - Herding
 


### PR DESCRIPTION
Fixes #20 

This PR adds a (symfony dispatched) UserHasRegistered event and an event subscriber that forms a new herd when it happens. The subscriber user the HerdRepository to discover if a herd already exists for that ShepherdId, so it won't create duplicates.

Oh, and it also fixes the recursive `$this->shepherdId()` call un the User entity.