### PR TITLE
Have an ignored local.yml group-var for develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.idea/codeStyleSettings.xml
 /.vagrant/
 /ansible/galaxy_roles/
+/ansible/group_vars/develop/local.yml
 /app/config/parameters.yml
 /build/
 /node_modules/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Fetch roles from Ansible Galaxy:
 
     ansible-galaxy install -r ansible/galaxy_roles.yml -f
 
+Create a local group_vars file for the develop environment, adjust it according to your needs.
+
+    cp ansible/group_vars/develop/local.dist ansible/group_vars/develop/local.yml
+
+If you want to be able to log in with twitter, you'll need to create an application at twitter, then place your key & secret in `local.yml`.
+
 Bring your box up:
 
     vagrant up --provision

--- a/ansible/group_vars/develop/local.dist
+++ b/ansible/group_vars/develop/local.dist
@@ -1,0 +1,17 @@
+---
+
+# safe to leave as is:
+
+mysql_root_password: not_so_secret_db_root_password
+
+mysql_passwords:
+  elewant_develop: not_so_secret_db_password
+
+elewant_secret: not_so_secret_symfony_secret
+
+# replace these with real values:
+
+elewant_delivery_address: replace_with_your_email_address
+
+elewant_twitter_client: replace_with_actual_twitter_client_key
+elewant_twitter_secret: replace_with_actual_twitter_client_secret

--- a/ansible/group_vars/develop/main.yml
+++ b/ansible/group_vars/develop/main.yml
@@ -10,10 +10,10 @@ ufw_rules_to_create:
 # MYSQL
 
 mysql_bind_address: 192.168.77.77
-mysql_root_password: 2lqYqTXfjIQ6746mrzB25ug0xedaxDcl # Place in secure.yml for non-develop groups!
+#mysql_root_password: <see local.yml>
 
-mysql_passwords:
-  elewant_develop: uj8bgtQyq0qhz3Z85iVi5Sgr6AawUH4r # Place in secure.yml for non-develop groups!
+#mysql_passwords:
+#  elewant_develop: <see local.yml>
 
 mysql_databases:
   - elewant_develop
@@ -46,7 +46,6 @@ php7_ini_directives_global:
   xdebug.remote_host: 192.168.77.1
   xdebug.remote_autostart: on
 
-
 php7_ini_directives_fpm:
   session.cookie_secure: off
 
@@ -73,7 +72,8 @@ elewant_server_name: develop.elewant.loc
 elewant_db_name: elewant_develop
 elewant_db_user: elewant_develop
 elewant_db_password: "{{ mysql_passwords.elewant_develop }}"
-elewant_delivery_address: staging@future500.nl
-elewant_secret: SaG125fH0Alz8NIMIQdYGQEizoeZJVlQlbpFIDgEhQeyOalfPBkvowShgFkaruVu
-elewant_twitter_client: 'needs_client_id'
-elewant_twitter_secret: 'needs_client_secret'
+
+#elewant_delivery_address: <see local.yml>
+#elewant_secret: <see local.yml>
+#elewant_twitter_client: <see local.yml>
+#elewant_twitter_secret: <see local.yml>


### PR DESCRIPTION
Instead of having sensitive information (like passwords) in the `group_vars` files directly, it's better to place them in a separate "vaulted" file. But for development we want everyone to be able to collaborate.

The PR introduces a `local.yml.dist` (in `ansible/group_vars/develop/`), which you can copy to `local.yml` and adjust to your needs. This `local.yml` is ignored by git, to prevent sensitive info from being committed.

This way you can safely destroy and (re)provision the vagrant box, without having to (re)enter those sensitive parts.

The readme is updated, so new people know what to do.