### PR TITLE
Fix sticky navbar & footer

### DIFF
--- a/src/Elewant/AppBundle/Resources/assets/scss/agency-theme.scss
+++ b/src/Elewant/AppBundle/Resources/assets/scss/agency-theme.scss
@@ -95,9 +95,22 @@ $gray-lighter: lighten($gray-base, 93.5%) !default; // #eee
 
 // Global Components
 
+html {
+  position: relative;
+  min-height: 100%;
+}
+
 body {
   overflow-x: hidden;
   @include body-font;
+}
+
+.body-shrink-always {
+  // Sticky navbar
+  padding-top: 54px;
+
+  // Semi-sticky footer
+  margin-bottom: 90px;
 }
 
 .text-primary {
@@ -643,6 +656,13 @@ footer {
   color: $white;
   padding: 25px 0;
   text-align: center;
+
+  // Semi-sticky footer
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 90px;
+
   span.copyright {
     font-size: 90%;
     line-height: 40px;

--- a/src/Elewant/AppBundle/Resources/views/Layout/base.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Layout/base.html.twig
@@ -17,7 +17,7 @@
     <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}">
 </head>
 
-<body id="page-top">
+<body id="page-top"{% if not shrinking_navbar|default(false) %} class="body-shrink-always"{% endif %}>
 
 {% include 'ElewantAppBundle:Layout:navbar.html.twig' %}
 


### PR DESCRIPTION
Make the footer semi-sticky: it sticks to the bottom of the window when the content doesn't reach the bottom, but doesn't stay on-screen when the content is larger than the screen.

Also adds a bit of padding to the body when in "always shrink" mode, so content element aren't hidden beneath it.