### PR TITLE
Integrating login interfaces

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -10,10 +10,13 @@ hwi_oauth_login:
     resource: "@HWIOAuthBundle/Resources/config/routing/login.xml"
     prefix:   /login
 
-twitter_login:
+hwi_oauth_twitter_login:
+    path: /connect/twitter
+
+hwi_oauth_twitter_login_check:
     path: /login/check-twitter
 
-logout:
+hwi_oauth_logout:
     path: /logout
 
 elewant_app:

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -16,13 +16,13 @@ security:
                 oauth_user_provider:
                     service:  elewant.security.user_provider
                 resource_owners:
-                    twitter:  "/login/check-twitter"
-                login_path:   /login
-                failure_path: /login
+                    twitter:  hwi_oauth_twitter_login_check
+                login_path:   hwi_oauth_twitter_login
+                failure_path: root
                 use_forward:  false
             logout:
-                path:   /logout
-                target: /
+                path:   hwi_oauth_logout
+                target: root
 
     access_control:
         - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/src/Elewant/AppBundle/Controller/DefaultController.php
+++ b/src/Elewant/AppBundle/Controller/DefaultController.php
@@ -19,4 +19,14 @@ class DefaultController extends Controller
             ['shrinking_navbar' => true]
         );
     }
+
+    /**
+     * @Route("/style-guide", name="style_guide")
+     */
+    public function styleGuideAction()
+    {
+        return $this->render(
+            'ElewantAppBundle:Default:style_guide.html.twig'
+        );
+    }
 }

--- a/src/Elewant/AppBundle/Resources/assets/scss/agency-theme.scss
+++ b/src/Elewant/AppBundle/Resources/assets/scss/agency-theme.scss
@@ -238,9 +238,10 @@ header {
   background-size: cover;
   text-align: center;
   color: white;
+  height: 100vh;
+
   .intro-text {
     padding-top: 100px;
-    padding-bottom: 50px;
     .intro-lead-in {
       @include serif-font;
       font-style: italic;
@@ -262,7 +263,6 @@ header {
   header {
     .intro-text {
       padding-top: 250px;
-      padding-bottom: 250px;
       .intro-lead-in {
         @include serif-font;
         font-style: italic;

--- a/src/Elewant/AppBundle/Resources/assets/scss/elewant.scss
+++ b/src/Elewant/AppBundle/Resources/assets/scss/elewant.scss
@@ -7,3 +7,9 @@
 @import "agency-theme";
 // Font Awesome
 @import "../../../../../../node_modules/font-awesome/scss/font-awesome";
+
+
+// Alert icons
+.alert .fa {
+  margin-right: 0.5rem;
+}

--- a/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
@@ -1,3 +1,5 @@
+{% import 'ElewantAppBundle:Macros:utils.html.twig' as utils %}
+
 <header>
     <div class="container">
 
@@ -14,10 +16,7 @@
         </div>
 
         {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
-            <div class="alert alert-danger" role="alert">
-                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                Welcome {{ app.user.displayName }}!
-            </div>
+            {{ utils.alert('Welcome ' ~ app.user.displayName ~ '!', 'success') }}
         {% endif %}
 
     </div>

--- a/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
@@ -1,11 +1,24 @@
-
-<!-- Header -->
 <header>
     <div class="container">
+
         <div class="intro-text">
             <div class="intro-lead-in">Welcome elePHPants around the world!</div>
             <div class="intro-heading">It's nice to meet you</div>
-            <a href="#services" class="page-scroll btn btn-xl"><i class="fa fa-twitter"></i> Join the herd</a>
+
+            {% if not is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+                <a href="{{ path('hwi_oauth_twitter_login') }}" class="page-scroll btn btn-xl">
+                    <i class="fa fa-twitter" aria-hidden="true"></i>
+                    Join the herd
+                </a>
+            {% endif %}
         </div>
+
+        {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+            <div class="alert alert-danger" role="alert">
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                Welcome {{ app.user.displayName }}!
+            </div>
+        {% endif %}
+
     </div>
 </header>

--- a/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
@@ -9,8 +9,7 @@
 
             {% if not is_granted('IS_AUTHENTICATED_REMEMBERED') %}
                 <a href="{{ path('hwi_oauth_twitter_login') }}" class="page-scroll btn btn-xl">
-                    <i class="fa fa-twitter" aria-hidden="true"></i>
-                    Join the herd
+                    {{ utils.icon('twitter') }} Join the herd
                 </a>
             {% endif %}
         </div>

--- a/src/Elewant/AppBundle/Resources/views/Default/style_guide.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Default/style_guide.html.twig
@@ -1,0 +1,18 @@
+{% extends 'ElewantAppBundle:Layout:base.html.twig' %}
+
+{% import 'ElewantAppBundle:Macros:utils.html.twig' as utils %}
+
+{% block body %}
+
+    <div class="container mt-3">
+
+        {# Alerts #}
+
+        {{ utils.alert('You successfully read this important alert message.', 'success') }}
+        {{ utils.alert('Better check yourself, you\'re not looking too good.', 'warning') }}
+        {{ utils.alert('Change a few things up and try submitting again.', 'danger') }}
+        {{ utils.alert('This alert needs your attention, but it\'s not super important.') }}
+
+    </div>
+
+{% endblock %}

--- a/src/Elewant/AppBundle/Resources/views/Layout/navbar.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Layout/navbar.html.twig
@@ -3,21 +3,16 @@
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
             Menu <i class="fa fa-bars"></i>
         </button>
-        <a class="navbar-brand page-scroll" href="#page-top">Elewant</a>
+        <a class="navbar-brand page-scroll" href="{{ path('root') }}">Elewant</a>
         <div class="collapse navbar-collapse" id="navbarResponsive">
             <ul class="navbar-nav ml-auto">
-                <li class="nav-item">
-                    <a class="nav-link page-scroll" href="#services">Services</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link page-scroll" href="#portfolio">Portfolio</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link page-scroll" href="#about">About</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link page-scroll" href="#team">Team</a>
-                </li>
+                <li class="nav-item"><a class="nav-link page-scroll" href="#services">Services</a></li>
+                <li class="nav-item"><a class="nav-link page-scroll" href="#portfolio">Portfolio</a></li>
+                <li class="nav-item"><a class="nav-link page-scroll" href="#about">About</a></li>
+                <li class="nav-item"><a class="nav-link page-scroll" href="#team">Team</a></li>
+                {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+                    <li class="nav-item"><a class="nav-link" href="{{ path('hwi_oauth_logout') }}">Logout</a></li>
+                {% endif %}
             </ul>
         </div>
     </div>

--- a/src/Elewant/AppBundle/Resources/views/Macros/utils.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Macros/utils.html.twig
@@ -1,0 +1,21 @@
+{% macro alert(message, type, icon) %}
+    {% if not icon %}
+        {% if type == 'success' %}
+            {% set icon = 'check-circle-o' %}
+        {% elseif type == 'warning' %}
+            {% set icon = 'exclamation-triangle' %}
+        {% elseif type == 'danger' %}
+            {% set icon = 'exclamation-circle' %}
+        {% else %}
+            {% set icon = 'info-circle' %}
+        {% endif %}
+    {% endif %}
+
+    <div class="alert alert-{{ type | default('info') }} alert-dismissible fade show" role="alert">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+        <i class="fa fa-{{ icon }}" aria-hidden="true"></i>
+        {{ message }}
+    </div>
+{% endmacro %}

--- a/src/Elewant/AppBundle/Resources/views/Macros/utils.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Macros/utils.html.twig
@@ -1,3 +1,7 @@
+{% macro icon(icon) %}
+    <i class="fa fa-{{ icon }}" aria-hidden="true"></i>
+{% endmacro %}
+
 {% macro alert(message, type, icon) %}
     {% if not icon %}
         {% if type == 'success' %}

--- a/src/Elewant/UserBundle/Resources/views/Connect/login.html.twig
+++ b/src/Elewant/UserBundle/Resources/views/Connect/login.html.twig
@@ -1,10 +1,25 @@
 {% extends 'HWIOAuthBundle::layout.html.twig' %}
 
 {% block hwi_oauth_content %}
-    {% if error is defined and error %}
-        <span>{{ error }}</span>
-    {% endif %}
-    {% for owner in hwi_oauth_resource_owners() %}
-        <a href="{{ hwi_oauth_login_url(owner) }}">{{ owner | trans({}, 'HWIOAuthBundle') }}</a> <br />
-    {% endfor %}
+
+    <div class="container">
+        <section>
+
+            {% if error is defined and error %}
+                <div class="alert alert-danger" role="alert">
+                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                    {{ error }}
+                </div>
+            {% endif %}
+
+            {% for owner in hwi_oauth_resource_owners() %}
+                <a href="{{ hwi_oauth_login_url(owner) }}" class="btn btn-lg btn-primary" role="button">
+                    <i class="fa fa-{{ owner }}" aria-hidden="true"></i>
+                    Login with {{ owner | trans({}, 'HWIOAuthBundle') }}
+                </a>
+            {% endfor %}
+
+        </section>
+    </div>
+
 {% endblock hwi_oauth_content %}

--- a/src/Elewant/UserBundle/Resources/views/Connect/login.html.twig
+++ b/src/Elewant/UserBundle/Resources/views/Connect/login.html.twig
@@ -13,8 +13,7 @@
 
             {% for owner in hwi_oauth_resource_owners() %}
                 <a href="{{ hwi_oauth_login_url(owner) }}" class="btn btn-lg btn-primary" role="button">
-                    <i class="fa fa-{{ owner }}" aria-hidden="true"></i>
-                    Login with {{ owner | trans({}, 'HWIOAuthBundle') }}
+                    {{ utils.icon(owner) }} Login with {{ owner | trans({}, 'HWIOAuthBundle') }}
                 </a>
             {% endfor %}
 

--- a/src/Elewant/UserBundle/Resources/views/Connect/login.html.twig
+++ b/src/Elewant/UserBundle/Resources/views/Connect/login.html.twig
@@ -1,15 +1,14 @@
 {% extends 'HWIOAuthBundle::layout.html.twig' %}
 
+{% import 'ElewantAppBundle:Macros:utils.html.twig' as utils %}
+
 {% block hwi_oauth_content %}
 
     <div class="container">
         <section>
 
             {% if error is defined and error %}
-                <div class="alert alert-danger" role="alert">
-                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                    {{ error }}
-                </div>
+                {{ utils.alert(error, 'danger') }}
             {% endif %}
 
             {% for owner in hwi_oauth_resource_owners() %}


### PR DESCRIPTION
- Integrating the "login" view, which actually only used when logging in / connecting fails.
- Create a style guide (at `/style-guide`).
- Add a macro for alerts and icons (and use them).