### PR TITLE
Improve file templates and inspections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.idea/*
 !.idea/codeStyleSettings.xml
+!.idea/fileTemplates/
+!.idea/inspectionProfiles/
 /.vagrant/
 /ansible/galaxy_roles/
 /ansible/group_vars/develop/local.yml

--- a/.idea/fileTemplates/code/PHP Constructor.php
+++ b/.idea/fileTemplates/code/PHP Constructor.php
@@ -1,0 +1,1 @@
+public function __construct(${PARAM_LIST}) {${BODY}}

--- a/.idea/fileTemplates/code/PHP Fluent Setter Method.php
+++ b/.idea/fileTemplates/code/PHP Fluent Setter Method.php
@@ -1,0 +1,5 @@
+public function set${NAME}(#if (${SCALAR_TYPE_HINT})${SCALAR_TYPE_HINT} #else${TYPE_HINT} #end$${PARAM_NAME})#if(${RETURN_TYPE}) : ${CLASS_NAME}#else#end
+{
+    $this->${FIELD_NAME} = $${PARAM_NAME};
+    return $this;
+}

--- a/.idea/fileTemplates/code/PHP Getter Method.php
+++ b/.idea/fileTemplates/code/PHP Getter Method.php
@@ -1,0 +1,8 @@
+public ${STATIC} function ${FIELD_NAME}()#if(${RETURN_TYPE}) : ${RETURN_TYPE}#else#end
+{
+#if (${STATIC} == "static")
+    return self::$${FIELD_NAME};
+#else
+    return $this->${FIELD_NAME};
+#end
+}

--- a/.idea/fileTemplates/code/PHP Setter Method.php
+++ b/.idea/fileTemplates/code/PHP Setter Method.php
@@ -1,0 +1,8 @@
+public ${STATIC} function set${NAME}(#if (${SCALAR_TYPE_HINT})${SCALAR_TYPE_HINT} #else${TYPE_HINT} #end$${PARAM_NAME})
+{
+#if (${STATIC} == "static")
+    self::$${FIELD_NAME} = $${PARAM_NAME};
+#else
+    $this->${FIELD_NAME} = $${PARAM_NAME};
+#end
+}

--- a/.idea/fileTemplates/includes/PHP Field Doc Comment.php
+++ b/.idea/fileTemplates/includes/PHP Field Doc Comment.php
@@ -1,0 +1,4 @@
+/**
+ * ${TYPE_TAG} ${TYPE_HINT}
+ */
+ 

--- a/.idea/fileTemplates/internal/PHP Class.php
+++ b/.idea/fileTemplates/internal/PHP Class.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+#if (${NAMESPACE})
+namespace ${NAMESPACE};
+#end
+
+final class ${NAME}
+{
+
+}

--- a/.idea/fileTemplates/internal/PHP File.php
+++ b/.idea/fileTemplates/internal/PHP File.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/.idea/fileTemplates/internal/PHP Interface.php
+++ b/.idea/fileTemplates/internal/PHP Interface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+#if (${NAMESPACE})
+namespace ${NAMESPACE};
+#end
+
+interface ${NAME}
+{
+
+}

--- a/.idea/fileTemplates/internal/PHP Trait.php
+++ b/.idea/fileTemplates/internal/PHP Trait.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+#if (${NAMESPACE})
+namespace ${NAMESPACE};
+#end
+
+trait ${NAME}
+{
+
+}

--- a/.idea/fileTemplates/internal/PHPUnit 6 Test.php
+++ b/.idea/fileTemplates/internal/PHPUnit 6 Test.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+#if (${NAMESPACE})
+namespace ${NAMESPACE};
+#end
+
+#if (${TESTED_NAME} && ${NAMESPACE} && !${TESTED_NAMESPACE})
+use ${TESTED_NAME};
+#elseif (${TESTED_NAME} && ${TESTED_NAMESPACE} && ${NAMESPACE} != ${TESTED_NAMESPACE})
+use ${TESTED_NAMESPACE}\\${TESTED_NAME};
+#end
+use PHPUnit\Framework\TestCase;
+
+final class ${NAME} extends TestCase
+{
+
+}

--- a/.idea/fileTemplates/internal/PHPUnit Test.php
+++ b/.idea/fileTemplates/internal/PHPUnit Test.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+#if (${NAMESPACE})
+namespace ${NAMESPACE};
+#end
+
+#if (${TESTED_NAME} && ${NAMESPACE} && !${TESTED_NAMESPACE})
+use ${TESTED_NAME};
+#elseif (${TESTED_NAME} && ${TESTED_NAMESPACE} && ${NAMESPACE} != ${TESTED_NAMESPACE})
+use ${TESTED_NAMESPACE}\\${TESTED_NAME};
+#end
+
+final class ${NAME} extends#if(${NAMESPACE}) \PHPUnit_Framework_TestCase #else PHPUnit_Framework_TestCase #end
+{
+
+}

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,8 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PhpMissingStrictTypesDeclarationInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SqlDialectInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SqlNoDataSourceInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>


### PR DESCRIPTION
Change the PHP file templates: adding `declare(strict_types=1);`, `final`, remove unnecessary doc-blocks, add type-hints and return-types, and use getters without `get` prefix.

Also change some inspections: warn when `declare(strict_types=1);` is missing, don't wine about sql dialect and data-source.