### PR TITLE
Change the country type to a select list of countries (fixes #83)

### DIFF
--- a/src/Elewant/UserBundle/Form/UserType.php
+++ b/src/Elewant/UserBundle/Form/UserType.php
@@ -7,6 +7,7 @@ namespace Elewant\UserBundle\Form;
 use Elewant\UserBundle\Entity\User;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\CountryType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -19,7 +20,7 @@ class UserType extends AbstractType implements DataMapperInterface
         $builder
             ->add('username', TextType::class, ['disabled' => true])
             ->add('displayName', TextType::class)
-            ->add('country', TextType::class)
+            ->add('country', CountryType::class)
             ->setDataMapper($this);
     }
 


### PR DESCRIPTION
The country comes from Twitter data, and is a free-form field there. If the country _happens to be_ a 2-letter value [ISO_3166-1_alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), then the country is preselected correctly.
In any other case (like "The Netherlands", or "Rotterdam area" or something similar) the country is preset to the top value `Afganistan`.

So we are caught between having a proper country in our data for use later on, or just accepting whatever Twitter has and trying to use whatever it is when the time comes to convert that value to lat/long.

I'm not sure what is the best approach here....