### PR TITLE
Feature/improve readability of unit tests

### DIFF
--- a/src/Elewant/AppBundle/Controller/TestApiCommandController.php
+++ b/src/Elewant/AppBundle/Controller/TestApiCommandController.php
@@ -21,7 +21,10 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-final class ApiCommandController
+/**
+ * This controller is only used in the develop and test environments.
+ */
+final class TestApiCommandController
 {
     /**
      * @var CommandBus

--- a/src/Elewant/AppBundle/Resources/config/routing.yml
+++ b/src/Elewant/AppBundle/Resources/config/routing.yml
@@ -1,15 +1,15 @@
 'command::form-herd':
-    path: '/api/commands/form-herd'
+    path: '/testapi/commands/form-herd'
     defaults: { _controller: elewant.api_command_controller:postAction, prooph_command_name: 'Elewant\Herding\Model\Commands\FormHerd' }
 
 'command::adopt-elephpant':
-    path: '/api/commands/adopt-elephpant'
+    path: '/testapi/commands/adopt-elephpant'
     defaults: { _controller: elewant.api_command_controller:postAction, prooph_command_name: 'Elewant\Herding\Model\Commands\AdoptElePHPant' }
 
 'command::abandon-elephpant':
-    path: '/api/commands/abandon-elephpant'
+    path: '/testapi/commands/abandon-elephpant'
     defaults: { _controller: elewant.api_command_controller:postAction, prooph_command_name: 'Elewant\Herding\Model\Commands\AbandonElePHPant' }
 
 'command::abandon-herd':
-    path: '/api/commands/abandon-herd'
+    path: '/testapi/commands/abandon-herd'
     defaults: { _controller: elewant.api_command_controller:postAction, prooph_command_name: 'Elewant\Herding\Model\Commands\AbandonHerd' }

--- a/src/Elewant/AppBundle/Resources/config/services.yml
+++ b/src/Elewant/AppBundle/Resources/config/services.yml
@@ -22,7 +22,7 @@ services:
             - { name: kernel.event_subscriber }
 
     elewant.api_command_controller:
-        class: Elewant\AppBundle\Controller\ApiCommandController
+        class: Elewant\AppBundle\Controller\TestApiCommandController
         arguments: ['@prooph_service_bus.herding_command_bus', '@prooph_service_bus.message_factory']
 
     elewant.form_herd_handler:

--- a/tests/AppBundle/Controller/ApiCommandAbandonElePHPantTest.php
+++ b/tests/AppBundle/Controller/ApiCommandAbandonElePHPantTest.php
@@ -7,6 +7,7 @@ namespace Tests\Elewant\AppBundle\Controller;
 use Elewant\Herding\Model\Breed;
 use Elewant\Herding\Model\Events\ElePHPantWasAbandonedByHerd;
 use Elewant\Herding\Model\ShepherdId;
+use PHPUnit\Framework\TestCase;
 
 class ApiCommandAbandonElePHPantTest extends ApiCommandBase
 {
@@ -29,19 +30,19 @@ class ApiCommandAbandonElePHPantTest extends ApiCommandBase
 
     public function test_command_abandon_elephpant_returns_http_status_202()
     {
-        $this->assertEquals(202, $this->client->getResponse()->getStatusCode());
+        TestCase::assertEquals(202, $this->client->getResponse()->getStatusCode());
     }
 
     public function test_command_abandon_elephpant_emits_ElePHPantWasAdoptedByHerd_event()
     {
-        $this->assertCount(3, $this->recordedEvents);
+        TestCase::assertCount(3, $this->recordedEvents);
 
         $eventUnderTest = $this->recordedEvents['2'];
 
-        $this->assertInstanceOf(ElePHPantWasAbandonedByHerd::class, $eventUnderTest);
-        $this->assertSame(Breed::BLACK_AMSTERDAMPHP_REGULAR, $eventUnderTest->breed()->toString());
-        $this->assertTrue($this->adoptedElePHPantId->equals($eventUnderTest->elePHPantId()));
-        $this->assertTrue($this->herdId->equals($eventUnderTest->herdId()));
+        TestCase::assertInstanceOf(ElePHPantWasAbandonedByHerd::class, $eventUnderTest);
+        TestCase::assertSame(Breed::BLACK_AMSTERDAMPHP_REGULAR, $eventUnderTest->breed()->toString());
+        TestCase::assertTrue($this->adoptedElePHPantId->equals($eventUnderTest->elePHPantId()));
+        TestCase::assertTrue($this->herdId->equals($eventUnderTest->herdId()));
     }
 
     public function test_command_abandon_elephpant_created_a_correct_herd_projection()
@@ -51,7 +52,7 @@ class ApiCommandAbandonElePHPantTest extends ApiCommandBase
 
         $shouldBeEmpty = $this->retrieveElePHPantFromListing($eventUnderTest->elePHPantId()->toString());
 
-        $this->assertEmpty($shouldBeEmpty,
+        TestCase::assertEmpty($shouldBeEmpty,
             sprintf('An ElePHPant (%s) is still projected after being abandonded.', $eventUnderTest->elePHPantId()->toString())
         );
     }

--- a/tests/AppBundle/Controller/ApiCommandAbandonHerdTest.php
+++ b/tests/AppBundle/Controller/ApiCommandAbandonHerdTest.php
@@ -8,6 +8,7 @@ use Elewant\Herding\Model\Breed;
 use Elewant\Herding\Model\Events\HerdWasAbandoned;
 use Elewant\Herding\Model\HerdId;
 use Elewant\Herding\Model\ShepherdId;
+use PHPUnit\Framework\TestCase;
 
 class ApiCommandAbandonHerdTest extends ApiCommandBase
 {
@@ -28,16 +29,16 @@ class ApiCommandAbandonHerdTest extends ApiCommandBase
 
     public function test_command_abandon_herd_returns_http_status_202()
     {
-        $this->assertEquals(202, $this->client->getResponse()->getStatusCode());
+        TestCase::assertEquals(202, $this->client->getResponse()->getStatusCode());
     }
 
     public function test_command_abandon_herd_emits_HerdWasAbandoned_event()
     {
-        $this->assertCount(3, $this->recordedEvents);
+        TestCase::assertCount(3, $this->recordedEvents);
 
         $eventUnderTest = $this->recordedEvents[2];
-        $this->assertInstanceOf(HerdWasAbandoned::class, $eventUnderTest);
-        $this->assertTrue($this->herdId->equals($eventUnderTest->herdId()));
+        TestCase::assertInstanceOf(HerdWasAbandoned::class, $eventUnderTest);
+        TestCase::assertTrue($this->herdId->equals($eventUnderTest->herdId()));
     }
 
     public function test_command_abandon_herd_created_a_correct_herd_projection()
@@ -48,10 +49,10 @@ class ApiCommandAbandonHerdTest extends ApiCommandBase
         $shouldBeEmpty = $this->retrieveHerdFromListing($eventUnderTest->herdId()->toString());
         $shouldBeEmptyElePHPants = $this->retrieveHerdElePHPantsFromListing($eventUnderTest->herdId()->toString());
 
-        $this->assertEmpty($shouldBeEmpty,
+        TestCase::assertEmpty($shouldBeEmpty,
             sprintf('A Herd (%s) is still projected after being abandonded.', $eventUnderTest->herdId()->toString())
         );
-        $this->assertEmpty($shouldBeEmptyElePHPants,
+        TestCase::assertEmpty($shouldBeEmptyElePHPants,
             sprintf('ElePHPants for a herd (%s) are still projected after the herd is abandonded.', $eventUnderTest->herdId()->toString())
         );
     }

--- a/tests/AppBundle/Controller/ApiCommandAdoptElePHPantTest.php
+++ b/tests/AppBundle/Controller/ApiCommandAdoptElePHPantTest.php
@@ -7,6 +7,7 @@ namespace Tests\Elewant\AppBundle\Controller;
 use Elewant\Herding\Model\Breed;
 use Elewant\Herding\Model\Events\ElePHPantWasAdoptedByHerd;
 use Elewant\Herding\Model\ShepherdId;
+use PHPUnit\Framework\TestCase;
 
 class ApiCommandAdoptElePHPantTest extends ApiCommandBase
 {
@@ -25,19 +26,19 @@ class ApiCommandAdoptElePHPantTest extends ApiCommandBase
 
     public function test_command_adopt_elephpant_returns_http_status_202()
     {
-        $this->assertEquals(202, $this->client->getResponse()->getStatusCode());
+        TestCase::assertEquals(202, $this->client->getResponse()->getStatusCode());
     }
 
     public function test_command_adopt_elephpant_emits_ElePHPantWasAdoptedByHerd_event()
     {
-        $this->assertCount(2, $this->recordedEvents);
+        TestCase::assertCount(2, $this->recordedEvents);
 
         /** @var ElePHPantWasAdoptedByHerd $eventUnderTest */
         $eventUnderTest = $this->recordedEvents[1];
 
-        $this->assertInstanceOf(ElePHPantWasAdoptedByHerd::class, $eventUnderTest);
-        $this->assertSame(Breed::BLACK_AMSTERDAMPHP_REGULAR, $eventUnderTest->breed()->toString());
-        $this->assertTrue($this->herdId->equals($eventUnderTest->herdId()));
+        TestCase::assertInstanceOf(ElePHPantWasAdoptedByHerd::class, $eventUnderTest);
+        TestCase::assertSame(Breed::BLACK_AMSTERDAMPHP_REGULAR, $eventUnderTest->breed()->toString());
+        TestCase::assertTrue($this->herdId->equals($eventUnderTest->herdId()));
     }
 
     public function test_command_adopt_elephpant_created_a_correct_herd_projection()
@@ -52,7 +53,7 @@ class ApiCommandAdoptElePHPantTest extends ApiCommandBase
             'adopted_on'   => $eventUnderTest->createdAt()->format('Y-m-d H:i:s'),
         ];
         $projectedElePHPant          = $this->retrieveElePHPantFromListing($eventUnderTest->elePHPantId()->toString());
-        $this->assertSame($expectedElePHPantProjection, $projectedElePHPant);
+        TestCase::assertSame($expectedElePHPantProjection, $projectedElePHPant);
     }
 
 }

--- a/tests/AppBundle/Controller/ApiCommandBase.php
+++ b/tests/AppBundle/Controller/ApiCommandBase.php
@@ -34,7 +34,7 @@ abstract class ApiCommandBase extends WebTestCase
             'herdName'   => $name,
         ];
 
-        return $this->request('POST', '/api/commands/form-herd', $payload);
+        return $this->request('POST', '/testapi/commands/form-herd', $payload);
     }
 
     protected function adoptElePHPant(HerdId $herdId, Breed $breed)
@@ -44,7 +44,7 @@ abstract class ApiCommandBase extends WebTestCase
             'breed'  => $breed->toString(),
         ];
 
-        return $this->request('POST', '/api/commands/adopt-elephpant', $payload);
+        return $this->request('POST', '/testapi/commands/adopt-elephpant', $payload);
     }
 
     protected function abandonElePHPant(HerdId $herdId, Breed $breed)
@@ -54,7 +54,7 @@ abstract class ApiCommandBase extends WebTestCase
             'breed'  => $breed->toString(),
         ];
 
-        return $this->request('POST', '/api/commands/abandon-elephpant', $payload);
+        return $this->request('POST', '/testapi/commands/abandon-elephpant', $payload);
     }
 
     protected function abandonHerd(HerdId $herdId, ShepherdId $shepherdId)
@@ -64,7 +64,7 @@ abstract class ApiCommandBase extends WebTestCase
             'shepherdId' => $shepherdId->toString(),
         ];
 
-        return $this->request('POST', '/api/commands/abandon-herd', $payload);
+        return $this->request('POST', '/testapi/commands/abandon-herd', $payload);
     }
 
     private function request(string $type, string $url, array $payload)

--- a/tests/AppBundle/Controller/ApiCommandFormHerdTest.php
+++ b/tests/AppBundle/Controller/ApiCommandFormHerdTest.php
@@ -6,6 +6,7 @@ namespace Tests\Elewant\AppBundle\Controller;
 
 use Elewant\Herding\Model\Events\HerdWasFormed;
 use Elewant\Herding\Model\ShepherdId;
+use PHPUnit\Framework\TestCase;
 
 class ApiCommandFormHerdTest extends ApiCommandBase
 {
@@ -21,17 +22,17 @@ class ApiCommandFormHerdTest extends ApiCommandBase
 
     public function test_command_form_herd_returns_http_status_202()
     {
-        $this->assertEquals(202, $this->client->getResponse()->getStatusCode());
+        TestCase::assertEquals(202, $this->client->getResponse()->getStatusCode());
     }
 
     public function test_command_form_herd_emits_HerdWasFormed_event()
     {
-        $this->assertCount(1, $this->recordedEvents);
+        TestCase::assertCount(1, $this->recordedEvents);
 
         /** @var HerdWasFormed $eventUnderTest */
         $eventUnderTest = $this->recordedEvents[0];
-        $this->assertInstanceOf(HerdWasFormed::class, $eventUnderTest);
-        $this->assertSame('My herd name', $eventUnderTest->name());
+        TestCase::assertInstanceOf(HerdWasFormed::class, $eventUnderTest);
+        TestCase::assertSame('My herd name', $eventUnderTest->name());
     }
 
     public function test_command_form_herd_created_a_correct_herd_projection()
@@ -46,6 +47,6 @@ class ApiCommandFormHerdTest extends ApiCommandBase
             'formed_on'   => $eventUnderTest->createdAt()->format('Y-m-d H:i:s'),
         ];
         $projectedHerd = $this->retrieveHerdFromListing($eventUnderTest->herdId()->toString());
-        $this->assertSame($expectedHerdProjection, $projectedHerd);
+        TestCase::assertSame($expectedHerdProjection, $projectedHerd);
     }
 }


### PR DESCRIPTION
During WeCamp, while explaning the code and the tests, this came up as an improvement:

- Replace $this->assert with static Testcase::assert calls to improve readability (reduce similarity to the `$this` in phpspec)
- Rename ApiController to TestApiController and /testapi/ path to avoid confusion that this is not actually an API in the application.

Fixes #82 