### PR TITLE
Repair the navbar links and rename camelcase twig variable

### DIFF
--- a/src/Elewant/AppBundle/Controller/DefaultController.php
+++ b/src/Elewant/AppBundle/Controller/DefaultController.php
@@ -23,7 +23,8 @@ class DefaultController extends Controller
             'ElewantAppBundle:Default:index.html.twig',
             [
                 'shrinking_navbar' => true,
-                'newestHerds'      => $newestHerds,
+                'only_anchors_in_navbar' => true,
+                'newest_herds'      => $newestHerds,
             ]
         );
     }

--- a/src/Elewant/AppBundle/Resources/views/Default/index.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Default/index.html.twig
@@ -4,7 +4,7 @@
 
     {% include 'ElewantAppBundle:Default:header.html.twig' %}
     {% include 'ElewantAppBundle:Default:about.html.twig' %}
-    {% include 'ElewantAppBundle:Default:newest_herds.html.twig' with {'herds': newestHerds}%}
+    {% include 'ElewantAppBundle:Default:newest_herds.html.twig' with {'herds': newest_herds}%}
     {% include 'ElewantAppBundle:Default:contributors.html.twig' %}
 
 {% endblock %}

--- a/src/Elewant/AppBundle/Resources/views/Default/newest_herds.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Default/newest_herds.html.twig
@@ -11,7 +11,7 @@
         <div class="row">
             <div class="col-lg-12">
                 <ul class="timeline">
-                    {% for herd in newestHerds %}
+                    {% for herd in newest_herds %}
                         <li class="{% if loop.index is odd %}timeline-inverted{% endif %}">
                             <div class="timeline-image">
                                 <img class="rounded-circle img-fluid" src="{{ asset('bundles/elewantapp/img/newest-herds/' ~ loop.index ~ '.jpg') }}" alt="">

--- a/src/Elewant/AppBundle/Resources/views/Layout/navbar.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Layout/navbar.html.twig
@@ -6,9 +6,9 @@
         <a class="navbar-brand page-scroll" href="{{ path('root') }}">Elewant</a>
         <div class="collapse navbar-collapse" id="navbarResponsive">
             <ul class="navbar-nav ml-auto">
-                <li class="nav-item"><a class="nav-link page-scroll" href="#about">About</a></li>
-                <li class="nav-item"><a class="nav-link page-scroll" href="#newest_herds">Newest Herds</a></li>
-                <li class="nav-item"><a class="nav-link page-scroll" href="#contributors">Contributors</a></li>
+                <li class="nav-item"><a class="nav-link page-scroll" href="{% if not only_anchors_in_navbar|default(false) %}{{ path('root') }}{% endif %}#about">About</a></li>
+                <li class="nav-item"><a class="nav-link page-scroll" href="{% if not only_anchors_in_navbar|default(false) %}{{ path('root') }}{% endif %}#newest_herds">Newest Herds</a></li>
+                <li class="nav-item"><a class="nav-link page-scroll" href="{% if not only_anchors_in_navbar|default(false) %}{{ path('root') }}{% endif %}#contributors">Contributors</a></li>
                 {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
                     <li class="nav-item"><a class="nav-link" href="{{ path('herd_tending') }}">My Herd</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ path('hwi_oauth_logout') }}">Logout</a></li>


### PR DESCRIPTION
Rename the `newestHerds` twig variable to `newest_herds`
Add a variable to twig called `only_anchors_in_navbar` that does not render the {{ path }} part of the links (resulting in `#anchors` on the homepage but full paths anywhere else).

Fixes #94 