### PR TITLE
Login flow

### DIFF
--- a/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
@@ -17,5 +17,6 @@
                 </a>
             {% endif %}
         </div>
+
     </div>
 </header>

--- a/src/Elewant/UserBundle/Resources/translations/ElewantUserBundle.en.yml
+++ b/src/Elewant/UserBundle/Resources/translations/ElewantUserBundle.en.yml
@@ -1,0 +1,23 @@
+header:
+  connecting: 'Connecting'
+  success: 'Successfully connected'
+  register: 'Registering'
+  registration_success: 'Successfully registered'
+
+paragraph:
+  connecting: |
+    Welcome back %name%!
+    You have successfully connected your %service% account.
+  register: |
+    Welcome %name%!
+    You have successfully registered an account with the username "%username%".
+  herd_tending: Go tend to your herd.
+
+connect:
+  confirm:
+    cancel: 'Cancel'
+    submit: 'Connect'
+    text: 'Are you sure that you want to connect your %service% account "%name%" to your current account?'
+  registration:
+    cancel: 'Cancel'
+    submit: 'Register'

--- a/src/Elewant/UserBundle/Resources/views/Connect/connect_confirm.html.twig
+++ b/src/Elewant/UserBundle/Resources/views/Connect/connect_confirm.html.twig
@@ -1,17 +1,17 @@
 {% extends 'HWIOAuthBundle::layout.html.twig' %}
 
 {% block hwi_oauth_content %}
-    <h3>{{ 'header.connecting' | trans({}, 'HWIOAuthBundle') }}</h3>
+    <h3>{{ 'header.connecting' | trans({}, 'ElewantUserBundle') }}</h3>
 
     <div class="row">
         <div class="col-md-9 col-lg-6">
-            <p>{{ 'connect.confirm.text' | trans({'%service%': service | trans({}, 'HWIOAuthBundle'), '%name%': userInformation.realName}, 'HWIOAuthBundle') }}</p>
+            <p>{{ 'connect.confirm.text' | trans({'%service%': ('service.' ~ service) | trans({}, 'ElewantUserBundle'), '%name%': userInformation.realName}, 'ElewantUserBundle') }}</p>
 
             {{ form_start(form, {'action': path('hwi_oauth_connect_service', {'service': service, 'key': key}), 'attr': {'class': 'fos_user_registration_register'}}) }}
             {{ form_widget(form) }}
             <div class="form-group">
-                <button type="submit" class="btn btn-primary">{{ 'connect.confirm.submit' | trans({}, 'HWIOAuthBundle') }}</button>
-                <a href="{{ path('hwi_oauth_connect') }}" class="btn">{{ 'connect.confirm.cancel' | trans({}, 'HWIOAuthBundle') }}</a>
+                <button type="submit" class="btn btn-primary">{{ 'connect.confirm.submit' | trans({}, 'ElewantUserBundle') }}</button>
+                <a href="{{ path('hwi_oauth_connect') }}" class="btn">{{ 'connect.confirm.cancel' | trans({}, 'ElewantUserBundle') }}</a>
             </div>
             {{ form_end(form) }}
         </div>

--- a/src/Elewant/UserBundle/Resources/views/Connect/connect_success.html.twig
+++ b/src/Elewant/UserBundle/Resources/views/Connect/connect_success.html.twig
@@ -2,6 +2,8 @@
 
 {% block hwi_oauth_content %}
 
-    <h3>{{ 'header.success' | trans({'%name%': userInformation.realName}, 'HWIOAuthBundle') }}</h3>
+    <h3>{{ 'header.success' | trans({}, 'ElewantUserBundle') }}</h3>
+    <p>{{ 'paragraph.connecting' | trans({'%name%': app.user.displayName, '%service%': ('service.' ~ service) | trans({}, 'ElewantUserBundle')}, 'ElewantUserBundle') | nl2br }}</p>
+    <p><a href="{{ path('herd_tending') }}">{{ 'paragraph.herd_tending' | trans({}, 'ElewantUserBundle') }}</a></p>
 
 {% endblock hwi_oauth_content %}

--- a/src/Elewant/UserBundle/Resources/views/Connect/login.html.twig
+++ b/src/Elewant/UserBundle/Resources/views/Connect/login.html.twig
@@ -10,7 +10,7 @@
 
     {% for owner in hwi_oauth_resource_owners() %}
         <a href="{{ hwi_oauth_login_url(owner) }}" class="btn btn-lg btn-primary" role="button">
-            {{ utils.icon(owner) }} Login with {{ owner | trans({}, 'HWIOAuthBundle') }}
+            {{ utils.icon(owner) }} Login with {{ owner | trans({}, 'ElewantUserBundle') }}
         </a>
     {% endfor %}
 

--- a/src/Elewant/UserBundle/Resources/views/Connect/registration.html.twig
+++ b/src/Elewant/UserBundle/Resources/views/Connect/registration.html.twig
@@ -2,15 +2,15 @@
 
 {% block hwi_oauth_content %}
 
-    <h3>{{ 'header.register' | trans({'%name%': userInformation.realName}, 'HWIOAuthBundle') }}</h3>
+    <h3>{{ 'header.register' | trans({'%name%': userInformation.realName}, 'ElewantUserBundle') }}</h3>
 
     <div class="row">
         <div class="col-md-9 col-lg-6">
             {{ form_start(form, {'action': path('hwi_oauth_connect_registration', {'key': key}), 'attr': {'class': 'hwi_oauth_registration_register'}}) }}
             {{ form_widget(form) }}
             <div class="form-group">
-                <button type="submit" class="btn btn-primary">{{ 'connect.registration.submit'|trans({}, 'HWIOAuthBundle') }}</button>
-                <a href="{{ path('hwi_oauth_connect') }}" class="btn">{{ 'connect.registration.cancel' | trans({}, 'HWIOAuthBundle') }}</a>
+                <button type="submit" class="btn btn-primary">{{ 'connect.registration.submit'|trans({}, 'ElewantUserBundle') }}</button>
+                <a href="{{ path('hwi_oauth_connect') }}" class="btn">{{ 'connect.registration.cancel' | trans({}, 'ElewantUserBundle') }}</a>
             </div>
             {{ form_end(form) }}
         </div>

--- a/src/Elewant/UserBundle/Resources/views/Connect/registration_success.html.twig
+++ b/src/Elewant/UserBundle/Resources/views/Connect/registration_success.html.twig
@@ -2,6 +2,8 @@
 
 {% block hwi_oauth_content %}
 
-    <h3>{{ 'header.registration_success' | trans({'%username%': app.user.username}, 'HWIOAuthBundle') }}</h3>
+    <h3>{{ 'header.registration_success' | trans({}, 'ElewantUserBundle') }}</h3>
+    <p>{{ 'paragraph.register' | trans({'%name%': app.user.displayName, '%username%': app.user.username}, 'ElewantUserBundle') | nl2br }}</p>
+    <p><a href="{{ path('herd_tending') }}">{{ 'paragraph.herd_tending' | trans({}, 'ElewantUserBundle') }}</a></p>
 
 {% endblock hwi_oauth_content %}


### PR DESCRIPTION
I was unable to implement a redirect or alternative page, so instead I've updated the success pages to look a bit nicer, and point you in the right direction.

![success](https://user-images.githubusercontent.com/738933/30479362-273512ee-9a15-11e7-9ee0-6eb0acd7cc02.png)


Fixes #110 