### PR TITLE
Add shepherd/herd search through autocomplete

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,12 @@ module.exports = function (grunt) {
                     'web/build/js/jquery-easing.min.js.map': 'node_modules/jquery-easing/dist/jquery.easing.1.3.umd.min.js.map'
                 }
             },
+            'jquery-easy-autocomplete': {
+                files: {
+                    'web/build/js/jquery.easy-autocomplete.js': 'node_modules/easy-autocomplete/dist/jquery.easy-autocomplete.js',
+                    'web/build/js/jquery.easy-autocomplete.min.js': 'node_modules/easy-autocomplete/dist/jquery.easy-autocomplete.min.js'
+                }
+            },
             popper: {
                 files: {
                     'web/build/js/popper.js': 'node_modules/popper.js/dist/umd/popper.js',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "clean-css-cli": "^4.1.6",
     "node-sass": "^4.5.3",
     "postcss-cli": "^4.1.0",
-    "uglify-js": "^3.0.27"
+    "uglify-js": "^3.0.27",
+    "easy-autocomplete": "^1.3.5"
   },
   "main": "Gruntfile.js",
   "repository": {

--- a/src/Elewant/AppBundle/Controller/ShepherdController.php
+++ b/src/Elewant/AppBundle/Controller/ShepherdController.php
@@ -8,8 +8,10 @@ use Elewant\AppBundle\Entity\Herd;
 use Elewant\AppBundle\Repository\HerdRepository;
 use Elewant\UserBundle\Entity\User;
 use Elewant\UserBundle\Security\UserProvider;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -21,9 +23,9 @@ class ShepherdController extends Controller
 {
 
     /**
-     * @Route("/{username}", name="shepherd_admire_herd")
+     * @Route("/admire/{username}", name="shepherd_admire_herd")
      */
-    public function shepherdAdmireHerdAction($username)
+    public function admireHerdAction($username)
     {
         $user = $this->getUserByUsername($username);
         $herd = $this->getHerd($user);
@@ -35,6 +37,21 @@ class ShepherdController extends Controller
 
         return $this->render('ElewantAppBundle:Shepherd:admire_herd.html.twig', $data);
     }
+
+    /**
+     * @Route("/search", name="shepherd_search")
+     */
+    public function searchAction(Request $request)
+    {
+        /** @var HerdRepository $herdRepository */
+        $herdRepository = $this->get('elewant.herd.herd_repository');
+
+        $query = $request->get('q');
+        $usernames = $herdRepository->search($query);
+
+        return $this->json($usernames);
+    }
+
 
     /**
      * @param string $username

--- a/src/Elewant/AppBundle/Repository/HerdRepository.php
+++ b/src/Elewant/AppBundle/Repository/HerdRepository.php
@@ -59,9 +59,12 @@ EOQ;
     public function search(string $searchString) : array
     {
         $dql = <<<EOQ
-SELECT h
+SELECT h.name, u.username
 FROM ElewantAppBundle:Herd h
-WHERE h.name LIKE :searchString
+JOIN ElewantUserBundle:User u WITH h.shepherdId = u.shepherdId
+WHERE 
+  h.name LIKE :searchString 
+  OR u.username LIKE :searchString
 ORDER BY h.formedOn DESC
 EOQ;
 

--- a/src/Elewant/AppBundle/Resources/assets/js/elewant.js
+++ b/src/Elewant/AppBundle/Resources/assets/js/elewant.js
@@ -1,6 +1,27 @@
+$(function () {
+    $("#search-input").easyAutocomplete({
+        url: function (q) {
+            return "/shepherd/search?q=" + q;
+        },
+        list: {
+            maxNumberOfElements: 6,
+            onChooseEvent: function() {
+                var username = $("#search-input").getSelectedItemData().username;
+                window.location.href = "/shepherd/admire/" + username;
+            }
+        },
+        theme: "bootstrap",
+        getValue: "name",
+        template: {
+            type: "description",
+            fields: {
+                description: "username"
+            }
+        },
+        requestDelay: 300
+    });
 
-$(function() {
-    $(".elephpant-controls .adopt").click(function(event) {
+    $(".elephpant-controls .adopt").click(function (event) {
         var breedChoice = $(event.target).data("breed");
 
         $.ajax({
@@ -13,7 +34,7 @@ $(function() {
         });
     });
 
-    $(".elephpant-controls .abandon").click(function(event) {
+    $(".elephpant-controls .abandon").click(function (event) {
         var breedChoice = $(event.target).data("breed");
 
         $.ajax({

--- a/src/Elewant/AppBundle/Resources/assets/scss/elewant.scss
+++ b/src/Elewant/AppBundle/Resources/assets/scss/elewant.scss
@@ -7,6 +7,8 @@
 @import "agency-theme";
 // Font Awesome
 @import "../../../../../../node_modules/font-awesome/scss/font-awesome";
+// easyAutocomplete
+@import "../../../../../../node_modules/easy-autocomplete/src/sass/easy-autocomplete";
 
 
 // Alert page

--- a/src/Elewant/AppBundle/Resources/views/Layout/base.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Layout/base.html.twig
@@ -38,6 +38,7 @@
 
 <script type="application/javascript" src="{{ asset('build/js/jquery.min.js') }}"></script>
 <script type="application/javascript" src="{{ asset('build/js/jquery-easing.min.js') }}"></script>
+<script type="application/javascript" src="{{ asset('build/js/jquery.easy-autocomplete.min.js') }}"></script>
 <script type="application/javascript" src="{{ asset('build/js/popper.min.js') }}"></script>
 <script type="application/javascript" src="{{ asset('build/js/bootstrap.min.js') }}"></script>
 

--- a/src/Elewant/AppBundle/Resources/views/Shepherd/admire_herd.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Shepherd/admire_herd.html.twig
@@ -1,6 +1,14 @@
 {% extends 'ElewantAppBundle:Layout:base.html.twig' %}
 
 {% block content %}
+    <section id="search">
+        <div class="col-sm-12">
+            <div class="form-group col-sm-4">
+                <input id="search-input" class="form-control" placeholder="Search..." autocomplete="off">
+            </div>
+        </div>
+    </section>
+
     <section id="herd_tending">
         <h3 class="mx-auto text-center">{{ herd.name }}</h3>
 


### PR DESCRIPTION
Fixes #70 

This PR introduces a search options on a shepherd's page. It searches on shepherd name as well as herd name. It shows the matches in a dropdown, as "**Herdname** - _shepherd name_".

On selection, it redirects the browser to the selected shepherd's page.

<img width="1148" alt="screen shot 2017-09-23 at 10 51 45" src="https://user-images.githubusercontent.com/668391/30771723-366270a6-a04e-11e7-8c6a-243c08795bb0.png">
<img width="1145" alt="screen shot 2017-09-23 at 10 52 06" src="https://user-images.githubusercontent.com/668391/30771724-36652774-a04e-11e7-8326-19caf66a2d33.png">
