### PR TITLE
Feature/add js routing bundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -18,6 +18,7 @@ class AppKernel extends Kernel
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
 
+            new FOS\JsRoutingBundle\FOSJsRoutingBundle(),
             new \Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
             new \HWI\Bundle\OAuthBundle\HWIOAuthBundle(),
 
@@ -34,11 +35,8 @@ class AppKernel extends Kernel
             $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
-
-            if (in_array($this->getEnvironment(), $this->developmentEnvironments, true)) {
-                $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
-                $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
-            }
+            $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
+            $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
         }
 
         return $bundles;

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,3 +1,6 @@
+fos_js_routing:
+    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
+
 hwi_oauth_redirect:
     resource: "@HWIOAuthBundle/Resources/config/routing/redirect.xml"
     prefix:   /connect
@@ -24,7 +27,3 @@ elewant_app:
     type:     annotation
     prefix:   /
 
-#elewant_user:
-#    resource: "@ElewantUserBundle/Controller/"
-#    type:     annotation
-#    prefix:   /

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "php-http/guzzle6-adapter": "^1.1",
         "twig/extensions": "^1.5",
         "php-http/cache-plugin": "^1.4",
-        "php-http/httplug-bundle": "^1.7"
+        "php-http/httplug-bundle": "^1.7",
+        "friendsofsymfony/jsrouting-bundle": "^1.6"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "717c01b4d61b0e3e6b4167480a539f64",
+    "content-hash": "e5b42083d57bb129dc5e6813720f6095",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1164,6 +1164,65 @@
                 "rest"
             ],
             "time": "2016-10-17T18:31:11+00:00"
+        },
+        {
+            "name": "friendsofsymfony/jsrouting-bundle",
+            "version": "1.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfSymfony/FOSJsRoutingBundle.git",
+                "reference": "49c1069132dcef371fb526351569deabeb6f0d8e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSJsRoutingBundle/zipball/49c1069132dcef371fb526351569deabeb6f0d8e",
+                "reference": "49c1069132dcef371fb526351569deabeb6f0d8e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2",
+                "symfony/console": "~2.3|3.*",
+                "symfony/framework-bundle": "~2.3|3.*",
+                "symfony/serializer": "~2.3|3.*",
+                "willdurand/jsonp-callback-validator": "~1.0"
+            },
+            "require-dev": {
+                "symfony/expression-language": "~2.4|3.*",
+                "symfony/phpunit-bridge": "^3.3"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "FOS\\JsRoutingBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "FriendsOfSymfony Community",
+                    "homepage": "https://github.com/friendsofsymfony/FOSJsRoutingBundle/contributors"
+                },
+                {
+                    "name": "William Durand",
+                    "email": "william.durand1@gmail.com"
+                }
+            ],
+            "description": "A pretty nice way to expose your Symfony2 routing to client applications.",
+            "homepage": "http://friendsofsymfony.github.com",
+            "keywords": [
+                "Js Routing",
+                "javascript",
+                "routing"
+            ],
+            "time": "2017-08-25T15:21:42+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -4347,6 +4406,46 @@
                 "templating"
             ],
             "time": "2017-06-07T18:47:58+00:00"
+        },
+        {
+            "name": "willdurand/jsonp-callback-validator",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/willdurand/JsonpCallbackValidator.git",
+                "reference": "1a7d388bb521959e612ef50c5c7b1691b097e909"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/willdurand/JsonpCallbackValidator/zipball/1a7d388bb521959e612ef50c5c7b1691b097e909",
+                "reference": "1a7d388bb521959e612ef50c5c7b1691b097e909",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonpCallbackValidator": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "William Durand",
+                    "email": "william.durand1@gmail.com",
+                    "homepage": "http://www.willdurand.fr"
+                }
+            ],
+            "description": "JSONP callback validator.",
+            "time": "2014-01-20T22:35:06+00:00"
         },
         {
             "name": "zendframework/zend-code",

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -28,3 +28,13 @@ extremely useful!
 to call the `equals()` method on the subject. Neat.
 
 ---
+
+**name:** Ramon de la Fuente
+
+**I learned about:** The FOS JS routing bundle. I was hardcoding routes into the javascript,
+but that is a problem if you ever want to change the url structure. The JS routing bundle gives
+access to routes from within javascript. I followed the manual 
+<http://symfony.com/doc/master/bundles/FOSJsRoutingBundle/index.html>, works like a charm.
+
+---
+

--- a/src/Elewant/AppBundle/Controller/HerdController.php
+++ b/src/Elewant/AppBundle/Controller/HerdController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * @Route("/herd")
+ * @Route("/herd", options={"expose"=true})
  * @Security("has_role('ROLE_USER')")
  */
 class HerdController extends Controller

--- a/src/Elewant/AppBundle/Controller/ShepherdController.php
+++ b/src/Elewant/AppBundle/Controller/ShepherdController.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * @Route("/shepherd")
+ * @Route("/shepherd", options={"expose"=true})
  */
 class ShepherdController extends Controller
 {

--- a/src/Elewant/AppBundle/Resources/assets/js/elewant.js
+++ b/src/Elewant/AppBundle/Resources/assets/js/elewant.js
@@ -25,7 +25,7 @@ $(function () {
         var breedChoice = $(event.target).data("breed");
 
         $.ajax({
-            url: Routing.generate('herd_adopt', { 'breed': breedChoice }),
+            url: Routing.generate('herd_adopt_breed', { 'breed': breedChoice }),
             data: [],
             success: function () {
                 var countInput = $(".elephpant-controls .count-" + breedChoice);
@@ -38,7 +38,7 @@ $(function () {
         var breedChoice = $(event.target).data("breed");
 
         $.ajax({
-            url: Routing.generate('herd_adopt', { 'breed': breedChoice }),
+            url: Routing.generate('herd_abandon_breed', { 'breed': breedChoice }),
             data: [],
             success: function () {
                 var countInput = $(".elephpant-controls .count-" + breedChoice);

--- a/src/Elewant/AppBundle/Resources/assets/js/elewant.js
+++ b/src/Elewant/AppBundle/Resources/assets/js/elewant.js
@@ -1,13 +1,13 @@
 $(function () {
     $("#search-input").easyAutocomplete({
         url: function (q) {
-            return "/shepherd/search?q=" + q;
+            return Routing.generate('shepherd_search', {'q': q});
         },
         list: {
             maxNumberOfElements: 6,
             onChooseEvent: function () {
                 var username = $("#search-input").getSelectedItemData().username;
-                window.location.href = "/shepherd/admire/" + username;
+                window.location.href = Routing.generate('shepherd_admire_herd', {'username': username});
             }
         },
         theme: "bootstrap",
@@ -25,7 +25,7 @@ $(function () {
         var breedChoice = $(event.target).data("breed");
 
         $.ajax({
-            url: '/herd/adopt/' + breedChoice,
+            url: Routing.generate('herd_adopt', { 'breed': breedChoice }),
             data: [],
             success: function () {
                 var countInput = $(".elephpant-controls .count-" + breedChoice);
@@ -38,7 +38,7 @@ $(function () {
         var breedChoice = $(event.target).data("breed");
 
         $.ajax({
-            url: '/herd/abandon/' + breedChoice,
+            url: Routing.generate('herd_adopt', { 'breed': breedChoice }),
             data: [],
             success: function () {
                 var countInput = $(".elephpant-controls .count-" + breedChoice);

--- a/src/Elewant/AppBundle/Resources/views/Layout/base.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Layout/base.html.twig
@@ -41,8 +41,8 @@
 <script type="application/javascript" src="{{ asset('build/js/popper.min.js') }}"></script>
 <script type="application/javascript" src="{{ asset('build/js/bootstrap.min.js') }}"></script>
 
-<script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
-<script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>
+<script type="application/javascript" src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+<script type="application/javascript" src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>
 
 <script type="application/javascript" src="{{ asset('build/js/elewant.min.js') }}"></script>
 

--- a/src/Elewant/AppBundle/Resources/views/Layout/base.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Layout/base.html.twig
@@ -41,6 +41,9 @@
 <script type="application/javascript" src="{{ asset('build/js/popper.min.js') }}"></script>
 <script type="application/javascript" src="{{ asset('build/js/bootstrap.min.js') }}"></script>
 
+<script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+<script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>
+
 <script type="application/javascript" src="{{ asset('build/js/elewant.min.js') }}"></script>
 
 </body>


### PR DESCRIPTION
Fixes #123 

This PR adds the FOS JS routing bundle, and enables it for the `/shepherd` and `/herd` routes.
All currently hardcoded JS routes have been replaced. The `options={"expose": true}` setting has been added to the `@Route` annotation on the controller class rather than the individual actions.

Pretty cool bundle. (I'm such a n00b)