### PR TITLE
Feature/simple local login for developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Fetch roles from Ansible Galaxy:
 
     ansible-galaxy install -r ansible/galaxy_roles.yml -f
 
-If you want to be able to log in with twitter, you'll need to create an application at app.twitter.com, 
+> If you want to be able to log in with twitter, you'll need to create an application at app.twitter.com, 
 then place your key & secret in a file called `ansible/provision/group_vars/develop/override_locally.yml`.
 
 Bring your box up:
@@ -63,66 +63,16 @@ You should be up-and-running!
 
     http://develop.elewant.loc/
 
-### Running the tests
+For developers, there is a special button on the front page to generate users for your local environment.
+Just click on "Developer login" and you should be able to create (and log in as) randomly created users.
 
-The core domain is tested with a BDD tool called [phpspec](http://www.phpspec.net/). You can find the specifications
-in the `/spec` folder, they 'describe' what the tested code should be doing, and can be run to verify that that is
-actually the case.
-
-    # running the phpspec test suite:
-    vendor/bin/phpspec run
-    vendor/bin/phpspec run spec/Path/To/A/Folder/
-    vendor/bin/phpspec run spec/Path/To/A/Specific/File.php
-
-Then there are some tests that try to run the application through the framework, after bootstrapping. This helps to
-verify that all the configuration/wiring is in order. Those tests are written in [phpunit](https://phpunit.de/), but using the Symfony
-WebTestCase as a base. The tests are located in the `/test` folder.
-
-    # running the phpunit test suite:
-    vendor/bin/phpunit
-    vendor/bin/phpunit tests/Path/To/A/Folder/
-    vendor/bin/phpunit tests/Path/To/A/Specific/File.php
-
-Additionally, we use the [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer/wiki) code style analysis tool to verify 
-that we do not violate the coding standards. There is a configuration file in the root called phpcs.xml, but it's
-basically PSR2 + some newer PHP7+ rules.
-
-    # running phpcs
-    vendor/bin/phpcs
-    vendor/bin/phpcs src/Path/To/A/Folder/
-    vendor/bin/phpcs src/Path/To/A/Specific/File.php
-
-Additionally, we use the [PHPStan](https://github.com/phpstan/phpstan) static analysis tool to verify that we do not 
-have any detectable PHP errors. 
-
-    # running phpstan
-    vendor/bin/phpstan analyse --configuration phpstan.neon --level 7 src
-
-For your convenience, there is also a file that ruins all suites back to back. That's also what Travis does.
-
-    # running all the tests
-    bin/run_tests
-
-### Cache, logs and sessions
-
-Normally these are kept in `var/cache`, `var/logs` and `var/sessions`.
-
-On the `develop` vagrant machine these are moved to `/dev/shm/elewant/var/cache`, `/dev/shm/elewant/var/logs` and `/dev/shm/elewant/var/sessions`.
-Moving them out of the synced folder (and into a shared memory disk) greatly improves performance.
+Have fun!
 
 ### Moar docs
 
-You can find more docs in the [/docs](/docs) folder.
+You can find more docs in the [/docs](/docs) folder, like:
 
-### Provision (only for those who have access to the production server)
-
-    # Production
-    ansible-playbook -i ansible/hosts-provision ansible/provision/playbook.yml --limit=production --ask-vault-pass
-
-### Deploy (only for those who have access to the production server)
-
-    # Staging
-    ansible-playbook -i ansible/hosts-deploy ansible/deploy/playbook.yml --limit=staging --extra="project_version=develop" --ask-vault-pass
-
-    # Production
-    ansible-playbook -i ansible/hosts-deploy ansible/deploy/playbook.yml --limit=production --extra="project_version=[VERSION]" --ask-vault-pass
+- How to run the tests [running_the_tests](/docs/running_the_tests.md)
+- Adding functionality to the [domain model](/docs/adding_functionality_to_the_model.md)
+- A few handy [notes for developers](/docs/notes_for_developers.md)
+- A neat list of [things people learned](/docs/lessons_learned.md) working on the project

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -37,6 +37,8 @@ class AppKernel extends Kernel
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
             $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
+
+            $bundles[] = new Elewant\DevelopmentBundle\ElewantDevelopmentBundle();
         }
 
         return $bundles;

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -16,3 +16,8 @@ _main:
 elewant_api_test:
     resource: "@ElewantAppBundle/Resources/config/routing.yml"
     prefix:   /
+
+elewant_development:
+    resource: "@ElewantDevelopmentBundle/Controller/"
+    type:     annotation
+    prefix:   /dev

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "phpunit/phpunit": "^6.3",
         "phpstan/phpstan": "^0.8.3",
         "squizlabs/php_codesniffer": "^3.1",
-        "slevomat/coding-standard": "^4.0"
+        "slevomat/coding-standard": "^4.0",
+        "fzaninotto/faker": "^1.7"
     },
     "scripts": {
         "symfony-scripts": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d7d6cd18cae9946ad26a046c4e0601a",
+    "content-hash": "9852091db41f7f2ae0bb2239c1321b50",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -4610,6 +4610,56 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "^4.0 || ^5.0",
+                "squizlabs/php_codesniffer": "^1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2017-08-15T16:48:10+00:00"
+        },
         {
             "name": "jean85/pretty-package-versions",
             "version": "1.0.1",

--- a/docs/adding_functionality_to_the_model.md
+++ b/docs/adding_functionality_to_the_model.md
@@ -1,5 +1,5 @@
 Adding functionality to the model
----------------------------------
+=================================
 
 Hey everyone. I'm glad you made it here. I'll try to explain how to "add functionality
 to the model" by using an example: adding a command to rename a Herd.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,0 +1,10 @@
+Deploying 
+=========
+
+(only for those who have access to the production server)
+
+    # Staging
+    ansible-playbook -i ansible/hosts-deploy ansible/deploy/playbook.yml --limit=staging --extra="project_version=develop" --ask-vault-pass
+
+    # Production
+    ansible-playbook -i ansible/hosts-deploy ansible/deploy/playbook.yml --limit=production --extra="project_version=[VERSION]" --ask-vault-pass

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -1,5 +1,5 @@
 Lessons Learned
----------------
+===============
 
 Hi there. We're proud to be a project aimed at learning, where anyone can join in 
 no matter their skill level. So we would like you to share with us what is it you've

--- a/docs/notes_for_developers.md
+++ b/docs/notes_for_developers.md
@@ -1,0 +1,20 @@
+Notes for developers
+====================
+
+### Cache, logs and sessions
+
+Normally these are kept in `var/cache`, `var/logs` and `var/sessions`.
+
+On the `develop` vagrant machine these are moved to `/dev/shm/elewant/var/cache`, `/dev/shm/elewant/var/logs` and `/dev/shm/elewant/var/sessions`.
+Moving them out of the synced folder (and into a shared memory disk) greatly improves performance.
+
+### Handy console commands
+
+    eventstore:herd:purge
+
+This removes all the events in the eventstore. Handy if you want to remove all the herds.
+
+    projection:herd:rebuild
+ 
+This truncates  the herd and elephpant tables, and rebuilds them by running all the events
+in the eventstore again. Handy if you are working on the projections and want to check your work

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -22,11 +22,6 @@ Run `visudo` to give provision user sudo rights
     chmod 600 /home/provision/.ssh/authorized_keys
     chown provision:provision /home/provision/.ssh -R
 
-Provisioning Production
-=======================
-
-    ansible-playbook -i ansible/hosts ansible/provision/provision.yml --ask-vault-pass --limit=production
-
 Provisioning Prodsim
 ====================
 
@@ -45,3 +40,9 @@ After the vagrant up, the playbook `setup_local_production_server.yml` has been 
 After you did a successful provision you can deploy your application to your prodsim
 
     ansible-playbook -i ansible/hosts ansible/deploy/deploy.yml --extra-vars "project_version=develop" --limit=prodsim --ask-vault-pass
+
+
+Provisioning Production
+=======================
+
+    ansible-playbook -i ansible/hosts-provision ansible/provision/playbook.yml --limit=production --ask-vault-pass

--- a/docs/running_the_tests.md
+++ b/docs/running_the_tests.md
@@ -1,0 +1,50 @@
+Running the tests
+=====================
+
+### PHPSPEC
+
+The core domain is tested with a BDD tool called [phpspec](http://www.phpspec.net/). You can find the specifications
+in the `/spec` folder, they 'describe' what the tested code should be doing, and can be run to verify that that is
+actually the case.
+
+    # running the phpspec test suite:
+    vendor/bin/phpspec run
+    vendor/bin/phpspec run spec/Path/To/A/Folder/
+    vendor/bin/phpspec run spec/Path/To/A/Specific/File.php
+
+### PHPUNIT
+
+Then there are some tests that try to run the application through the framework, after bootstrapping. This helps to
+verify that all the configuration/wiring is in order. Those tests are written in [phpunit](https://phpunit.de/), but using the Symfony
+WebTestCase as a base. The tests are located in the `/test` folder.
+
+    # running the phpunit test suite:
+    vendor/bin/phpunit
+    vendor/bin/phpunit tests/Path/To/A/Folder/
+    vendor/bin/phpunit tests/Path/To/A/Specific/File.php
+
+### PHPCS
+
+Additionally, we use the [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer/wiki) code style analysis tool to verify 
+that we do not violate the coding standards. There is a configuration file in the root called phpcs.xml, but it's
+basically PSR2 + some newer PHP7+ rules.
+
+    # running phpcs
+    vendor/bin/phpcs
+    vendor/bin/phpcs src/Path/To/A/Folder/
+    vendor/bin/phpcs src/Path/To/A/Specific/File.php
+
+### PHPSTAN
+
+Additionally, we use the [PHPStan](https://github.com/phpstan/phpstan) static analysis tool to verify that we do not 
+have any detectable PHP errors. 
+
+    # running phpstan
+    vendor/bin/phpstan analyse --configuration phpstan.neon --level 7 src
+
+### Running the entire suite
+
+For your convenience, there is also a file that runs all suites back to back. That's also what Travis does.
+
+    # running all the tests
+    bin/run_tests

--- a/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
@@ -9,6 +9,11 @@
                 <a href="{{ path('hwi_oauth_twitter_login') }}" class="page-scroll btn btn-xl">
                     {{ icon('twitter') }} {{ 'site.join-the-herd'|trans }}
                 </a>
+                {% if app.environment == 'dev' %}
+                    <a href="{{ path('dev_list_users') }}" class="page-scroll btn btn-xl">
+                        {{ icon('list') }} {{ 'site.join-the-herd'|trans }}
+                    </a>
+                {% endif %}
             {% else %}
                 <a href="{{ path('herd_tending') }}" class="page-scroll btn btn-xl">
                     {{ icon('edit') }} {{ 'site.tend-to-your-herd'|trans }}

--- a/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Default/header.html.twig
@@ -11,7 +11,7 @@
                 </a>
                 {% if app.environment == 'dev' %}
                     <a href="{{ path('dev_list_users') }}" class="page-scroll btn btn-xl">
-                        {{ icon('list') }} {{ 'site.join-the-herd'|trans }}
+                        {{ icon('list') }} {{ 'site.development_login'|trans  }}
                     </a>
                 {% endif %}
             {% else %}

--- a/src/Elewant/DevelopmentBundle/Controller/DevelopmentController.php
+++ b/src/Elewant/DevelopmentBundle/Controller/DevelopmentController.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\DevelopmentBundle\Controller;
+
+use Doctrine\ORM\EntityManager;
+use Elewant\DevelopmentBundle\Security\DevelopmentOauthResourceOwner;
+use Elewant\DevelopmentBundle\Security\DevelopmentUserResponse;
+use Elewant\UserBundle\Entity\User;
+use Elewant\UserBundle\Repository\UserRepository;
+use Elewant\UserBundle\Security\UserProvider;
+use Faker\Factory;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+
+final class DevelopmentController extends Controller
+{
+    /**
+     * @Route("/list-users", name="dev_list_users")
+     */
+    public function listUsersAction()
+    {
+        $users = $this->userRepository()->findAll();
+
+        return $this->render(
+            'ElewantDevelopmentBundle:Development:list_users.html.twig',
+            ['users' => $users]
+        );
+    }
+
+    /**
+     * @Route("generate-new-user", name="dev_generate_new_user")
+     */
+    public function generateNewUserAction()
+    {
+        $user = $this->generateRandomNewNuser();
+
+        $userResponse = new DevelopmentUserResponse(
+            [
+                'id'           => $user->username(),
+                'nickname'     => $user->displayName(),
+                'accessToken'  => 'access-token',
+                'refreshToken' => 'refresh-token',
+            ],
+            new DevelopmentOauthResourceOwner()
+        );
+
+        $this->userProvider()->connect($user, $userResponse);
+
+        return $this->redirectToRoute('dev_list_users');
+    }
+
+    /**
+     * @Route("/login-as/{username}", name="dev_login_as")
+     */
+    public function loginAsAction(Request $request, $username)
+    {
+        try {
+            $user = $this->userProvider()->loadUserByUsername($username);
+        } catch (UsernameNotFoundException $e) {
+            return $this->redirectToRoute('root');
+        }
+
+        $token = new UsernamePasswordToken($user, null, "secured_area", $user->getRoles());
+        $this->get("security.token_storage")->setToken($token);
+
+        //now dispatch the login event
+        $event = new InteractiveLoginEvent($request, $token);
+        $this->get("event_dispatcher")->dispatch("security.interactive_login", $event);
+
+        return $this->redirectToRoute('root');
+    }
+
+    private function userRepository(): UserRepository
+    {
+        /** @var EntityManager $em */
+        $em = $this->get('doctrine.orm.entity_manager');
+
+        /** @var UserRepository $userRepository */
+        $userRepository = $em->getRepository(User::class);
+
+        return $userRepository;
+    }
+
+    private function userProvider(): UserProvider
+    {
+        /** @var UserProvider $userProvider */
+        $userProvider = $this->get('elewant.security.user_provider');
+
+        return $userProvider;
+    }
+
+    private function generateRandomNewNuser(): User
+    {
+        $faker = Factory::create();
+
+        return new User($faker->userName, $faker->name, 'NL');
+    }
+}

--- a/src/Elewant/DevelopmentBundle/ElewantDevelopmentBundle.php
+++ b/src/Elewant/DevelopmentBundle/ElewantDevelopmentBundle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\DevelopmentBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class ElewantDevelopmentBundle extends Bundle
+{
+}

--- a/src/Elewant/DevelopmentBundle/Resources/translations/messages.en.yml
+++ b/src/Elewant/DevelopmentBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,6 @@
+site:
+  development_login: "Developer login"
+
+development:
+  login_with: "Login with"
+  generate_new_user: "Generate a new user"

--- a/src/Elewant/DevelopmentBundle/Resources/views/Development/list_users.html.twig
+++ b/src/Elewant/DevelopmentBundle/Resources/views/Development/list_users.html.twig
@@ -4,7 +4,7 @@
 
     <section id="dev_list_users">
         <div class="container">
-            <h3>Login with:</h3>
+            <h3>{{ 'development.login_with'|trans }}:</h3>
             {% for user in users %}
                 <a href="{{ path('dev_login_as', { 'username': user.username }) }}" class="btn btn-link">
                     {{ icon('eye') }} {{ user.username }}
@@ -16,7 +16,7 @@
     <section id="dev_generate_new_user">
         <div class="container">
             <a href="{{ path('dev_generate_new_user') }}" class="btn btn-primary">
-                {{ icon('plus') }} Generate a new user
+                {{ icon('plus') }} {{ 'development.generate_new_user'|trans }}
             </a>
         </div>
     </section>

--- a/src/Elewant/DevelopmentBundle/Resources/views/Development/list_users.html.twig
+++ b/src/Elewant/DevelopmentBundle/Resources/views/Development/list_users.html.twig
@@ -1,0 +1,24 @@
+{% extends 'ElewantAppBundle:Layout:base.html.twig' %}
+
+{% block body %}
+
+    <section id="dev_list_users">
+        <div class="container">
+            <h3>Login with:</h3>
+            {% for user in users %}
+                <a href="{{ path('dev_login_as', { 'username': user.username }) }}" class="btn btn-link">
+                    {{ icon('eye') }} {{ user.username }}
+                </a>
+            {% endfor %}
+        </div>
+    </section>
+
+    <section id="dev_generate_new_user">
+        <div class="container">
+            <a href="{{ path('dev_generate_new_user') }}" class="btn btn-primary">
+                {{ icon('plus') }} Generate a new user
+            </a>
+        </div>
+    </section>
+
+{% endblock body %}

--- a/src/Elewant/DevelopmentBundle/Security/DevelopmentOauthResourceOwner.php
+++ b/src/Elewant/DevelopmentBundle/Security/DevelopmentOauthResourceOwner.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\DevelopmentBundle\Security;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class DevelopmentOauthResourceOwner implements ResourceOwnerInterface
+{
+
+    public function getName()
+    {
+        return 'twitter';
+    }
+
+    public function isCsrfTokenValid($csrfToken)
+    {
+        return true;
+    }
+
+    public function handles(Request $request)
+    {
+        return true;
+    }
+
+    public function getUserInformation(array $accessToken, array $extraParameters = [])
+    {
+    }
+
+    public function getAuthorizationUrl($redirectUri, array $extraParameters = [])
+    {
+    }
+
+    public function getAccessToken(Request $request, $redirectUri, array $extraParameters = [])
+    {
+    }
+
+    public function getOption($name)
+    {
+    }
+
+    public function setName($name)
+    {
+    }
+}

--- a/src/Elewant/DevelopmentBundle/Security/DevelopmentUserResponse.php
+++ b/src/Elewant/DevelopmentBundle/Security/DevelopmentUserResponse.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\DevelopmentBundle\Security;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+
+final class DevelopmentUserResponse implements UserResponseInterface
+{
+
+    private $response;
+    /**
+     * @var ResourceOwnerInterface
+     */
+    private $resourceOwner;
+
+    public function __construct(array $response, ResourceOwnerInterface $resourceOwner)
+    {
+        $this->response      = $response;
+        $this->resourceOwner = $resourceOwner;
+    }
+
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    public function getResourceOwner()
+    {
+        return $this->resourceOwner;
+    }
+
+    public function getUsername()
+    {
+        return $this->response['identifier'];
+    }
+
+    public function getNickname()
+    {
+        return $this->response['nickname'];
+    }
+
+    public function getFirstName()
+    {
+        return $this->response['firstname'];
+    }
+
+    public function getLastName()
+    {
+        return $this->response['lastname'];
+    }
+
+    public function getRealName()
+    {
+        return $this->response['realname'];
+    }
+
+    public function getAccessToken()
+    {
+        return $this->response['accessToken'];
+    }
+
+    public function getRefreshToken()
+    {
+        return $this->response['refreshToken'];
+    }
+
+    public function getEmail()
+    {
+    }
+
+    public function getProfilePicture()
+    {
+    }
+
+    public function getTokenSecret()
+    {
+    }
+
+    public function getExpiresIn()
+    {
+    }
+
+    public function getOAuthToken()
+    {
+    }
+
+    public function setResponse($response)
+    {
+    }
+
+    public function setResourceOwner(ResourceOwnerInterface $resourceOwner)
+    {
+    }
+
+    public function setOAuthToken(OAuthToken $token)
+    {
+    }
+}


### PR DESCRIPTION
In order to give us some momentum for Hacktoberfest, I decided to write a simple implementation for "developer login" where we can generate users in the local development environment.

This does not replace #3, but it removes the pressure for it. We still only allow login with twitter on staging and production.

When generating new users, a random username is generated with Faker. We go throught the actual UserBundle, so the herd is created for the user just like if you connected through twitter.

<img width="937" alt="screen shot 2017-10-08 at 15 37 39" src="https://user-images.githubusercontent.com/668391/31317310-d3f26280-ac3e-11e7-906d-928211d63cb2.png">

<img width="607" alt="screen shot 2017-10-08 at 15 37 47" src="https://user-images.githubusercontent.com/668391/31317313-d8fd9542-ac3e-11e7-9165-bc898702a0e7.png">
