### PR TITLE
Feature/117 elephpant collection

### DIFF
--- a/spec/Elewant/Herding/Model/BreedCollectionSpec.php
+++ b/spec/Elewant/Herding/Model/BreedCollectionSpec.php
@@ -5,6 +5,7 @@ namespace spec\Elewant\Herding\Model;
 use Elewant\Herding\Model\Breed;
 use Elewant\Herding\Model\BreedCollection;
 use PhpSpec\ObjectBehavior;
+use Traversable;
 
 class BreedCollectionSpec extends ObjectBehavior
 {
@@ -28,6 +29,27 @@ class BreedCollectionSpec extends ObjectBehavior
         $this->add(Breed::fromString(Breed::WHITE_CONFOO_LARGE));
         $this->isEmpty()->shouldReturn(false);
     }
+
+    function it_can_be_counted()
+    {
+        $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
+        $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
+        $this->add($confoo);
+        $this->add($amsterdamPHP);
+
+        $this->count()->shouldReturn(2);
+    }
+
+    function it_can_be_iterated_over()
+    {
+        $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
+        $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
+        $this->add($confoo);
+        $this->add($amsterdamPHP);
+
+        $this->getIterator()->shouldImplement(Traversable::class);
+    }
+
 
     function it_adds_breeds()
     {
@@ -100,9 +122,11 @@ class BreedCollectionSpec extends ObjectBehavior
         $this->add($confoo);
         $this->add($confoo);
 
-        $expected = BreedCollection::fromArray([
-            $confoo,
-        ]);
+        $expected = BreedCollection::fromArray(
+            [
+                $confoo,
+            ]
+        );
 
         $this->equals($expected)->shouldReturn(true);
     }

--- a/spec/Elewant/Herding/Model/BreedCollectionSpec.php
+++ b/spec/Elewant/Herding/Model/BreedCollectionSpec.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace spec\Elewant\Herding\Model;
+
+use Elewant\Herding\Model\Breed;
+use Elewant\Herding\Model\BreedCollection;
+use PhpSpec\ObjectBehavior;
+
+class BreedCollectionSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedThrough('fromArray', [[]]);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(BreedCollection::class);
+    }
+
+    function it_is_empty_without_breeds()
+    {
+        $this->isEmpty()->shouldReturn(true);
+    }
+
+    function it_is_not_empty_with_a_breed()
+    {
+        $this->add(Breed::fromString(Breed::WHITE_CONFOO_LARGE));
+        $this->isEmpty()->shouldReturn(false);
+    }
+
+    function it_returns_breeds()
+    {
+        $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
+        $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
+        $this->add($confoo);
+        $this->add($amsterdamPHP);
+
+        $expected = [
+            $confoo,
+            $amsterdamPHP,
+        ];
+
+        $this->breeds()->shouldReturn($expected);
+    }
+
+    function it_does_not_add_the_same_breed_more_than_once()
+    {
+        $confoo = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
+        $this->add($confoo);
+        $this->add($confoo);
+        $this->add($confoo);
+
+        $expected = [
+            $confoo,
+        ];
+
+        $this->breeds()->shouldReturn($expected);
+    }
+
+    function it_equals_another_empty_breedcollection()
+    {
+        $other = BreedCollection::fromArray([]);
+        $this->equals($other)->shouldReturn(true);
+    }
+
+    function it_equals_another_similar_breedcollection()
+    {
+        $other = BreedCollection::fromArray(
+            [
+                Breed::fromString(Breed::WHITE_CONFOO_LARGE),
+                Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR),
+            ]
+        );
+
+        $this->add(Breed::fromString(Breed::WHITE_CONFOO_LARGE));
+        $this->add(Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR));
+
+        $this->equals($other)->shouldReturn(true);
+    }
+
+    function it_does_not_equal_a_different_breedcollection()
+    {
+        $other = BreedCollection::fromArray(
+            [
+                Breed::fromString(Breed::WHITE_CONFOO_LARGE),
+            ]
+        );
+
+        $this->add(Breed::fromString(Breed::WHITE_CONFOO_LARGE));
+        $this->add(Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR));
+
+        $this->equals($other)->shouldReturn(false);
+    }
+
+    function it_merges_with_another_breedcollection()
+    {
+        $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
+        $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
+        $zf2          = Breed::fromString(Breed::GREEN_ZF2_LARGE);
+
+        $other = BreedCollection::fromArray(
+            [
+                $confoo,
+                $amsterdamPHP,
+                $zf2
+            ]
+        );
+
+        $expected = BreedCollection::fromArray(
+            [
+                $confoo,
+                $amsterdamPHP,
+                $zf2
+            ]
+        );
+
+        $this->add($confoo);
+        $this->merge($other);
+        $this->equals($expected)->shouldReturn(true);
+    }
+
+    function it_diffs_with_another_breedcollection()
+    {
+        $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
+        $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
+        $zf2          = Breed::fromString(Breed::GREEN_ZF2_LARGE);
+
+        $other = BreedCollection::fromArray(
+            [
+                $confoo,
+                $amsterdamPHP,
+                $zf2
+            ]
+        );
+
+        $expected = BreedCollection::fromArray(
+            [
+                $amsterdamPHP,
+                $zf2
+            ]
+        );
+
+        $this->add($confoo);
+        $actualCollection = $this->diff($other);
+        $actualCollection->equals($expected)->shouldReturn(true);
+    }
+
+}

--- a/spec/Elewant/Herding/Model/BreedCollectionSpec.php
+++ b/spec/Elewant/Herding/Model/BreedCollectionSpec.php
@@ -29,19 +29,68 @@ class BreedCollectionSpec extends ObjectBehavior
         $this->isEmpty()->shouldReturn(false);
     }
 
-    function it_returns_breeds()
+    function it_adds_breeds()
     {
         $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
         $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
         $this->add($confoo);
         $this->add($amsterdamPHP);
 
-        $expected = [
-            $confoo,
-            $amsterdamPHP,
-        ];
+        $expected = BreedCollection::fromArray(
+            [
+                $confoo,
+                $amsterdamPHP,
+            ]
+        );
 
-        $this->breeds()->shouldReturn($expected);
+        $this->equals($expected)->shouldReturn(true);
+    }
+
+    function it_removes_breeds()
+    {
+        $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
+        $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
+        $zf2          = Breed::fromString(Breed::GREEN_ZF2_LARGE);
+
+        $initialCollection = BreedCollection::fromArray(
+            [
+                $confoo,
+                $amsterdamPHP,
+                $zf2,
+            ]
+        );
+
+        $this->add($confoo);
+        $this->add($amsterdamPHP);
+        $this->add($zf2);
+        $this->equals($initialCollection)->shouldReturn(true);
+
+        $expected = BreedCollection::fromArray(
+            [
+                $confoo,
+                $amsterdamPHP,
+            ]
+        );
+
+        $this->remove($zf2);
+        $this->equals($expected)->shouldReturn(true);
+    }
+
+
+    function it_knows_when_it_contains_a_specific_breed()
+    {
+        $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
+        $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
+        $this->add($confoo);
+        $this->add($amsterdamPHP);
+
+        $this->contains($confoo)->shouldReturn(true);
+        $this->contains($amsterdamPHP)->shouldReturn(true);
+    }
+
+    function it_knows_when_it_does_not_contain_a_specific_breed()
+    {
+        $this->contains(Breed::fromString(Breed::WHITE_CONFOO_LARGE));
     }
 
     function it_does_not_add_the_same_breed_more_than_once()
@@ -51,11 +100,11 @@ class BreedCollectionSpec extends ObjectBehavior
         $this->add($confoo);
         $this->add($confoo);
 
-        $expected = [
+        $expected = BreedCollection::fromArray([
             $confoo,
-        ];
+        ]);
 
-        $this->breeds()->shouldReturn($expected);
+        $this->equals($expected)->shouldReturn(true);
     }
 
     function it_equals_another_empty_breedcollection()
@@ -103,7 +152,7 @@ class BreedCollectionSpec extends ObjectBehavior
             [
                 $confoo,
                 $amsterdamPHP,
-                $zf2
+                $zf2,
             ]
         );
 
@@ -111,7 +160,7 @@ class BreedCollectionSpec extends ObjectBehavior
             [
                 $confoo,
                 $amsterdamPHP,
-                $zf2
+                $zf2,
             ]
         );
 
@@ -120,7 +169,7 @@ class BreedCollectionSpec extends ObjectBehavior
         $this->equals($expected)->shouldReturn(true);
     }
 
-    function it_diffs_with_another_breedcollection()
+    function it_is_missing_breeds_when_compared_to_a_different_breedcollection()
     {
         $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
         $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
@@ -130,20 +179,95 @@ class BreedCollectionSpec extends ObjectBehavior
             [
                 $confoo,
                 $amsterdamPHP,
-                $zf2
+                $zf2,
             ]
         );
 
         $expected = BreedCollection::fromArray(
             [
                 $amsterdamPHP,
-                $zf2
+                $zf2,
             ]
         );
 
         $this->add($confoo);
-        $actualCollection = $this->diff($other);
+        $actualCollection = $this->isMissingBreedsWhenComparedTo($other);
         $actualCollection->equals($expected)->shouldReturn(true);
     }
 
+    function it_does_not_missing_any_breeds_when_compared_to_a_similar_breedcollection()
+    {
+        $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
+        $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
+        $zf2          = Breed::fromString(Breed::GREEN_ZF2_LARGE);
+
+        $other = BreedCollection::fromArray(
+            [
+                $confoo,
+                $amsterdamPHP,
+                $zf2,
+            ]
+        );
+
+        $expected = BreedCollection::fromArray([]);
+
+        $this->add($confoo);
+        $this->add($amsterdamPHP);
+        $this->add($zf2);
+        $actualCollection = $this->isMissingBreedsWhenComparedTo($other);
+        $actualCollection->equals($expected)->shouldReturn(true);
+    }
+
+
+    function it_has_breeds_in_common_with_an_overlapping_breedcollection()
+    {
+        $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
+        $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
+        $zf2          = Breed::fromString(Breed::GREEN_ZF2_LARGE);
+
+        $other = BreedCollection::fromArray(
+            [
+                $confoo,
+                $amsterdamPHP,
+                $zf2,
+            ]
+        );
+
+        $expected = BreedCollection::fromArray(
+            [
+                $confoo,
+            ]
+        );
+
+        $this->add($confoo);
+        $actualCollection = $this->hasBreedsInCommonWith($other);
+        $actualCollection->equals($expected)->shouldReturn(true);
+    }
+
+    function it_has_no_breeds_in_common_with_a_non_overlapping_breedcollection()
+    {
+        $confoo       = Breed::fromString(Breed::WHITE_CONFOO_LARGE);
+        $amsterdamPHP = Breed::fromString(Breed::BLACK_AMSTERDAMPHP_REGULAR);
+        $zf2          = Breed::fromString(Breed::GREEN_ZF2_LARGE);
+
+        $other = BreedCollection::fromArray(
+            [
+                $confoo,
+                $amsterdamPHP,
+            ]
+        );
+
+        $expected = BreedCollection::fromArray([]);
+
+        $this->add($zf2);
+        $actualCollection = $this->hasBreedsInCommonWith($other);
+        $actualCollection->equals($expected)->shouldReturn(true);
+    }
+
+    function it_returns_all_breeds()
+    {
+        $this->beConstructedThrough('all');
+        $this->shouldHaveType(BreedCollection::class);
+        $this->contains(Breed::fromString(Breed::WHITE_CONFOO_LARGE))->shouldReturn(true);
+    }
 }

--- a/spec/Elewant/Herding/Model/HerdSpec.php
+++ b/spec/Elewant/Herding/Model/HerdSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Elewant\Herding\Model;
 
 use Elewant\Herding\Model\Breed;
+use Elewant\Herding\Model\BreedCollection;
 use Elewant\Herding\Model\Herd;
 use Elewant\Herding\Model\ShepherdId;
 use Elewant\Herding\Model\SorryICanNotChangeHerd;
@@ -112,6 +113,20 @@ class HerdSpec extends ObjectBehavior
 
         $this->isAbandoned()->shouldReturn(true);
         $this->shouldThrow(SorryICanNotChangeHerd::class)->during('adoptElePHPant', [Breed::blueOriginalRegular()]);
+    }
+
+    function it_contains_a_breedcollection()
+    {
+        $this->adoptElePHPant(Breed::blueOriginalRegular());
+        $this->adoptElePHPant(Breed::greenZf2Regular());
+        $this->elePHPants()->shouldHaveCount(2);
+        $this->elePHPants()->shouldContainAnElePHPant(Breed::blueOriginalRegular());
+        $this->elePHPants()->shouldContainAnElePHPant(Breed::greenZf2Regular());
+
+        $this->breeds()->shouldBeAnInstanceOf(BreedCollection::class);
+        $this->breeds()->contains(Breed::blueOriginalRegular())->shouldReturn(true);
+        $this->breeds()->contains(Breed::greenZf2Regular())->shouldReturn(true);
+        $this->breeds()->contains(Breed::redLaravelRegular())->shouldReturn(false);
     }
 
     public function getMatchers()

--- a/src/Elewant/AppBundle/Controller/HerdController.php
+++ b/src/Elewant/AppBundle/Controller/HerdController.php
@@ -6,7 +6,7 @@ namespace Elewant\AppBundle\Controller;
 
 use Elewant\AppBundle\Entity\Herd;
 use Elewant\AppBundle\Repository\HerdRepository;
-use Elewant\Herding\Model\Breed;
+use Elewant\Herding\Model\BreedCollection;
 use Elewant\Herding\Model\Commands\AbandonElePHPant;
 use Elewant\Herding\Model\Commands\AdoptElePHPant;
 use Elewant\UserBundle\Entity\User;
@@ -34,9 +34,10 @@ class HerdController extends Controller
         $herd = $this->getHerd($user);
 
         $data = [
-            'user'   => $user,
-            'herd'   => $herd,
-            'breeds' => Breed::availableTypes(),
+            'user'          => $user,
+            'herd'          => $herd,
+            'regularBreeds' => BreedCollection::allRegular(),
+            'largeBreeds'   => BreedCollection::allLarge(),
         ];
 
         return $this->render('ElewantAppBundle:Herd:tending.html.twig', $data);

--- a/src/Elewant/AppBundle/Entity/ElePHPant.php
+++ b/src/Elewant/AppBundle/Entity/ElePHPant.php
@@ -14,7 +14,7 @@ use Elewant\Herding\Model\Breed;
 class ElePHPant
 {
     /**
-     * @ORM\ManyToOne(targetEntity="Elewant\AppBundle\Entity\Herd", inversedBy="elephpants")
+     * @ORM\ManyToOne(targetEntity="Elewant\AppBundle\Entity\Herd", inversedBy="elePHPants")
      * @ORM\JoinColumn(name="herd_id", referencedColumnName="herd_id", nullable=false)
      * @var Herd
      */

--- a/src/Elewant/AppBundle/Entity/Herd.php
+++ b/src/Elewant/AppBundle/Entity/Herd.php
@@ -7,6 +7,8 @@ namespace Elewant\AppBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Elewant\Herding\Model\Breed;
+use Elewant\Herding\Model\BreedCollection;
 
 /**
  * @ORM\Entity(repositoryClass="Elewant\AppBundle\Repository\HerdRepository")
@@ -44,11 +46,11 @@ class Herd
      * @ORM\OneToMany(targetEntity="Elewant\AppBundle\Entity\ElePHPant", mappedBy="herd", cascade={"persist"})
      * @var ArrayCollection
      */
-    private $elephpants;
+    private $elePHPants;
 
     private function __construct()
     {
-        $this->elephpants = new ArrayCollection();
+        $this->elePHPants = new ArrayCollection();
     }
 
     public function shepherdId(): string
@@ -73,21 +75,27 @@ class Herd
 
     public function elePHPants(): Collection
     {
-        return $this->elephpants;
+        return $this->elePHPants;
     }
 
-    public function elePHPantBreedCounts(): Collection
+    public function elePHPantBreeds(): BreedCollection
     {
-        $result = [];
-        foreach ($this->elephpants as $elephpant) {
-            $breed = $elephpant->breed()->toString();
-            if (!isset($result[$breed])) {
-                $result[$breed] = 0;
-            }
-            $result[$breed]++;
+        $collection = BreedCollection::fromArray([]);
+        foreach ($this->elePHPants as $elePHPant) {
+            $collection->add($elePHPant->breed());
         }
-        ksort($result);
 
-        return new ArrayCollection($result);
+        return $collection;
+    }
+
+    public function filteredByBreed(Breed $breed): Collection
+    {
+        $filtered = $this->elePHPants->filter(
+            function ($elephpant) use ($breed) {
+                return $elephpant->breed()->equals($breed);
+            }
+        );
+
+        return $filtered;
     }
 }

--- a/src/Elewant/AppBundle/Resources/translations/herd.en.yml
+++ b/src/Elewant/AppBundle/Resources/translations/herd.en.yml
@@ -7,6 +7,8 @@ adopting-help-text: >
   doubt, please check the definitive resource on the subject:
   %link%
 size-regular: "Regular sized:"
+all-regular-elephpants-owned: "You did the impossible! You own all the regular breeds!"
+all-large-elephpants-owned: "You did the impossible! You own all the large breeds!"
 size-large: "Large:"
 finished-button: "Finished"
 breed:

--- a/src/Elewant/AppBundle/Resources/views/Default/newest_herds.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Default/newest_herds.html.twig
@@ -27,8 +27,8 @@
                                 </div>
                                 <div class="timeline-body">
                                     <p class="text-muted">
-                                        {% for breed, count in entry.herd.elePHPantBreedCounts|slice(0,4, true) %}
-                                            - {{ ("breed." ~ breed)|trans({}, "herd") }}<br>
+                                        {% for breed in entry.herd.elePHPantBreeds %}
+                                        - {{ ("breed." ~ breed)|trans({}, "herd") }}<br>
                                         {% else %}
                                             {{ 'site.newest-herds.empty-herd'|trans }}
                                         {% endfor %}

--- a/src/Elewant/AppBundle/Resources/views/Herd/tending.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Herd/tending.html.twig
@@ -57,6 +57,10 @@
                             <div class="col-lg-3 col-sm-4 col-6 text-center mt-2">
                                 {{ elephpant(breed, 0, true) }}
                             </div>
+                        {% else %}
+                            <div class="col-12">
+                                {{ alert('all-regular-elephpants-owned'|trans, 'success') }}
+                            </div>
                         {% endfor %}
                     </div>
                     <div class="row mt-2">
@@ -68,6 +72,10 @@
                         {% for breed in herd.elePHPantBreeds.isMissingBreedsWhenComparedTo(largeBreeds) %}
                             <div class="col-lg-4 col-sm-4 col-6 text-center mt-2">
                                 {{ elephpant(breed, 0, true) }}
+                            </div>
+                        {% else %}
+                            <div class="col-12">
+                                {{ alert('all-large-elephpants-owned'|trans, 'success') }}
                             </div>
                         {% endfor %}
                     </div>

--- a/src/Elewant/AppBundle/Resources/views/Herd/tending.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Herd/tending.html.twig
@@ -7,14 +7,14 @@
 
         <h3 class="mx-auto text-center">{{ herd.name }}</h3>
 
-        {% if not herd.elePHPantBreedCounts|length %}
+        {% if herd.elePHPantBreeds.isEmpty %}
             {{ alert('no-elephpants-yet'|trans({'%name%': app.user.displayName}), 'warning') }}
         {% endif %}
 
         <div class="row text-center">
-            {% for breed, count in herd.elePHPantBreedCounts %}
+            {% for breed in herd.elePHPantBreeds %}
                 <div class="col-lg-2 col-md-3 col-sm-4 col-6 mt-2">
-                    {{ elephpant(breed, count, true) }}
+                    {{ elephpant(breed, herd.filteredByBreed(breed).count, true) }}
                 </div>
             {% endfor %}
         </div>
@@ -43,7 +43,7 @@
                     <div class="row mt-2">
                         <div class="col">
                             {% trans with {'%link%': '<a href="http://afieldguidetoelephpants.net/#index" target="_blank" rel="noopener noreferrer">A Field Guide to Elephpants</a>'} %}
-                                adopting-help-text
+                            adopting-help-text
                             {% endtrans %}
                         </div>
                     </div>
@@ -53,7 +53,7 @@
                         </div>
                     </div>
                     <div class="row mt-2">
-                        {% for breed in breeds if 'REGULAR' in breed %}
+                        {% for breed in herd.elePHPantBreeds.isMissingBreedsWhenComparedTo(regularBreeds) %}
                             <div class="col-lg-3 col-sm-4 col-6 text-center mt-2">
                                 {{ elephpant(breed, 0, true) }}
                             </div>
@@ -65,7 +65,7 @@
                         </div>
                     </div>
                     <div class="row">
-                        {% for breed in breeds if 'LARGE' in breed %}
+                        {% for breed in herd.elePHPantBreeds.isMissingBreedsWhenComparedTo(largeBreeds) %}
                             <div class="col-lg-4 col-sm-4 col-6 text-center mt-2">
                                 {{ elephpant(breed, 0, true) }}
                             </div>

--- a/src/Elewant/AppBundle/Resources/views/Shepherd/admire_herd.html.twig
+++ b/src/Elewant/AppBundle/Resources/views/Shepherd/admire_herd.html.twig
@@ -14,11 +14,12 @@
     <section id="herd_tending">
         <h3 class="mx-auto text-center">{{ herd.name }}</h3>
         <div class="row">
-            {% for breed, amount in herd.elePHPantBreedCounts %}
+            {% for breed in herd.elePHPantBreeds %}
                 <div class="col-6 col-sm-4 col-lg-3">
-                    {{ elephpant(breed, amount) }}
+                    {{ elephpant(breed, herd.filteredByBreed(breed).count) }}
                 </div>
             {% endfor %}
+
         </div>
     </section>
 

--- a/src/Elewant/Herding/Model/Breed.php
+++ b/src/Elewant/Herding/Model/Breed.php
@@ -74,7 +74,7 @@ class Breed
         $this->type = $type;
     }
 
-    public static function availableTypes()
+    public static function availableTypes(): array
     {
         $reflected  = new ReflectionClass(self::class);
         $validTypes = $reflected->getConstants();

--- a/src/Elewant/Herding/Model/BreedCollection.php
+++ b/src/Elewant/Herding/Model/BreedCollection.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\Herding\Model;
+
+final class BreedCollection
+{
+    /**
+     * @var Breed[]
+     */
+    private $breeds = [];
+
+    private function __construct()
+    {
+    }
+
+    public static function fromArray(array $breeds): self
+    {
+        $collection = new self();
+        foreach ($breeds as $breed) {
+            $collection->add($breed);
+        }
+
+        return $collection;
+    }
+
+    public function isEmpty(): bool
+    {
+        return count($this->breeds) === 0;
+    }
+
+    public function add(Breed $breed)
+    {
+        if (in_array($breed, $this->breeds)) {
+            return;
+        }
+
+        $this->breeds[] = $breed;
+    }
+
+    public function breeds()
+    {
+        return $this->breeds;
+    }
+
+    public function equals(BreedCollection $otherCollection)
+    {
+        $diff = array_diff($this->breeds, $otherCollection->breeds);
+
+        return empty($diff) && count($this->breeds) === count($otherCollection->breeds);
+    }
+
+    public function merge(BreedCollection $otherCollection)
+    {
+        array_map(
+            function (Breed $breed) {
+                $this->add($breed);
+            },
+            $otherCollection->breeds
+        );
+    }
+
+    public function diff(BreedCollection $otherCollection)
+    {
+        $newBreeds = array_diff($otherCollection->breeds, $this->breeds);
+
+        return BreedCollection::fromArray($newBreeds);
+    }
+}

--- a/src/Elewant/Herding/Model/BreedCollection.php
+++ b/src/Elewant/Herding/Model/BreedCollection.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Elewant\Herding\Model;
 
-final class BreedCollection
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+
+final class BreedCollection implements Countable, IteratorAggregate
 {
     /**
      * @var Breed[]
@@ -33,6 +38,23 @@ final class BreedCollection
         }
 
         return $collection;
+    }
+
+    public static function allRegular(): self
+    {
+        $collection = new self();
+        foreach (Breed::availableTypes() as $type) {
+            if (strstr($type, 'REGULAR') !== false) {
+                $collection->add(Breed::fromString($type));
+            }
+        }
+
+        return $collection;
+    }
+
+    public static function allLarge(): self
+    {
+        return self::allRegular()->isMissingBreedsWhenComparedTo(self::all());
     }
 
     public function isEmpty(): bool
@@ -98,5 +120,15 @@ final class BreedCollection
     public function contains(Breed $breed): bool
     {
         return in_array($breed, $this->breeds);
+    }
+
+    public function count(): int
+    {
+        return count($this->breeds);
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->breeds);
     }
 }

--- a/src/Elewant/Herding/Model/BreedCollection.php
+++ b/src/Elewant/Herding/Model/BreedCollection.php
@@ -25,12 +25,22 @@ final class BreedCollection
         return $collection;
     }
 
+    public static function all(): self
+    {
+        $collection = new self();
+        foreach (Breed::availableTypes() as $type) {
+            $collection->add(Breed::fromString($type));
+        }
+
+        return $collection;
+    }
+
     public function isEmpty(): bool
     {
         return count($this->breeds) === 0;
     }
 
-    public function add(Breed $breed)
+    public function add(Breed $breed): void
     {
         if (in_array($breed, $this->breeds)) {
             return;
@@ -39,19 +49,28 @@ final class BreedCollection
         $this->breeds[] = $breed;
     }
 
-    public function breeds()
+    public function remove(Breed $breed): void
+    {
+        if (!in_array($breed, $this->breeds)) {
+            return;
+        }
+
+        $this->breeds = array_diff($this->breeds, [$breed]);
+    }
+
+    public function breeds(): array
     {
         return $this->breeds;
     }
 
-    public function equals(BreedCollection $otherCollection)
+    public function equals(BreedCollection $otherCollection): bool
     {
         $diff = array_diff($this->breeds, $otherCollection->breeds);
 
         return empty($diff) && count($this->breeds) === count($otherCollection->breeds);
     }
 
-    public function merge(BreedCollection $otherCollection)
+    public function merge(BreedCollection $otherCollection): void
     {
         array_map(
             function (Breed $breed) {
@@ -61,10 +80,23 @@ final class BreedCollection
         );
     }
 
-    public function diff(BreedCollection $otherCollection)
+    public function isMissingBreedsWhenComparedTo(BreedCollection $otherCollection): self
     {
         $newBreeds = array_diff($otherCollection->breeds, $this->breeds);
 
         return BreedCollection::fromArray($newBreeds);
+    }
+
+    public function hasBreedsInCommonWith(BreedCollection $otherCollection): self
+    {
+        $newBreeds = array_intersect($otherCollection->breeds, $this->breeds);
+
+        return BreedCollection::fromArray($newBreeds);
+    }
+
+
+    public function contains(Breed $breed): bool
+    {
+        return in_array($breed, $this->breeds);
     }
 }


### PR DESCRIPTION
This PR adds a "BreedCollection" as a concept. This is part of a herd, and can be retrieved with the `elePHPantBreeds()` method. It can be iterated over, and it can be compared with other breedCollections with `equals()`, `isMissingBreedsWhenComparedTo()` and `hasBreedsInCommonWith()`
The BreedCollection class contains methods that can return a Collection of `allRegular()`, `allLarge()` or just `all()`.