### PR TITLE
Add cron to renew certificates

### DIFF
--- a/ansible/provision/playbook.yml
+++ b/ansible/provision/playbook.yml
@@ -18,6 +18,9 @@
     - name: Add github.com to known_hosts file
       lineinfile: dest=/etc/ssh/ssh_known_hosts line="{{ lookup('pipe', 'ssh-keyscan github.com') }}" state=present  create=yes mode=0644
 
+    - name: Setup cron for renew certificates
+      cron: name="certbot renew certificates" minute=0 hour=2,6 job="service nginx stop && certbot renew && service nginx start"
+
 - name: Provision globally
   hosts: all
   become: yes


### PR DESCRIPTION
We are forced to stop and start nginx because the certbot wants to use the port 443

```
The program nginx (process ID 32742) is already listening on TCP port 443. This
will prevent us from binding to that port. Please stop the nginx program
temporarily and then try again. For automated renewal, you may want to use a
script that stops and starts your webserver. You can find an example at
https://certbot.eff.org/docs/using.html#renewal . Alternatively you can use the
webroot plugin to renew without needing to stop and start your webserver.
```