### PR TITLE
Feature/add phpd alias for commandline debugging

### DIFF
--- a/ansible/provision/playbook.yml
+++ b/ansible/provision/playbook.yml
@@ -92,6 +92,12 @@
         line: cd /vagrant
         insertafter: EOF
 
+    - name: Add the phpd alias for easy debugging from cli
+      lineinfile:
+        dest: /home/vagrant/.profile
+        line: "alias phpd=\"php -dxdebug.remote_autostart=On\""
+        insertafter: EOF
+
     - name: Copy parameters.yml
       template:
         src: "{{ playbook_dir }}/../deploy/templates/app/parameters.yml.j2"

--- a/docs/notes_for_developers.md
+++ b/docs/notes_for_developers.md
@@ -18,3 +18,13 @@ This removes all the events in the eventstore. Handy if you want to remove all t
  
 This truncates  the herd and elephpant tables, and rebuilds them by running all the events
 in the eventstore again. Handy if you are working on the projections and want to check your work
+
+### Step debugging
+
+The Vagrantbox is set up with XDebug, ready to connect to your favorite IDE (I'm guessing that's PHPstorm).
+All you need to do is install an XDEBUG browser plugin, and set PHPStorm to listen to incoming connections.
+
+If you want to debug a console command, or one of the tests maybe, then you can use a convenient alias:
+
+    phpd bin/console
+    phpd vendor/bin/phpspec run

--- a/docs/running_the_tests.md
+++ b/docs/running_the_tests.md
@@ -15,8 +15,8 @@ actually the case.
 ### PHPUNIT
 
 Then there are some tests that try to run the application through the framework, after bootstrapping. This helps to
-verify that all the configuration/wiring is in order. Those tests are written in [phpunit](https://phpunit.de/), but using the Symfony
-WebTestCase as a base. The tests are located in the `/test` folder.
+verify that all the configuration/wiring is in order. Those tests are written in [phpunit](https://phpunit.de/), but
+using the Symfony WebTestCase as a base. The tests are located in the `/test` folder.
 
     # running the phpunit test suite:
     vendor/bin/phpunit
@@ -43,10 +43,19 @@ have any detectable PHP errors.
     vendor/bin/phpstan analyse --configuration phpstan.neon --level 7 src
     
 ### Humbug
-Additionally, we use the [Humbug](https://github.com/humbug/humbug) mutation testing tool to verify that the unit tests are covering code mutations. Thus preventing any accidental code change that is not caught by a PHPUnit Test.
+
+Additionally, we use the [Humbug](https://github.com/humbug/humbug) mutation testing tool to verify that the unit
+tests are covering code mutations. Thus preventing any accidental code change that is not caught by a PHPUnit Test.
 
     # running *bah!* Humbug
     TEST_SUITE=humbug bin/run_tests 
+
+### Debugging
+
+For all the test suites (or any other command) you have the option to run the debugger form the commandline:
+
+    # phpd is an alias for "php+start_the_debugger"
+    phpd vendor/bin/phpspec run
 
 ### Running the entire suite
 


### PR DESCRIPTION
Step debugging is a joy, but it's not always convenient to start it fmor the commandline. This PR adds an alias for PHP called `phpd` to make that easier.

Running php code with `phpd some/command` will start the debugger. Yay!