### PR TITLE
Use Zend Framework green for green Elephpants

### DIFF
--- a/src/Elewant/AppBundle/Resources/assets/scss/components/_elephpant.scss
+++ b/src/Elewant/AppBundle/Resources/assets/scss/components/_elephpant.scss
@@ -77,7 +77,7 @@
   }
 
   &.elephpant-green {
-    background-color: $green;
+    background-color: $zf-green;
   }
 
   &.elephpant-multicolored.elephpant-phpdiversity {

--- a/src/Elewant/AppBundle/Resources/assets/scss/variables/_custom.scss
+++ b/src/Elewant/AppBundle/Resources/assets/scss/variables/_custom.scss
@@ -18,6 +18,7 @@ $gray-lighter: $gray-300;
 
 $blue-light: #4886b6;
 $blue-dark: #2d3d8b;
+$zf-green: #68B604;
 $pink-light: #f669c7;
 $yellow-light: #ffd65b;
 $purple-light: #c073c5;


### PR DESCRIPTION
According to the Field Guide, the green ZF2 elePHPant uses the green of the ZF logo.  This will update the color of the elePHPant to that color while still retaining the same shade of green for other elements on the site

![Comparison of green used for Bootstrap vs the ZF green](https://user-images.githubusercontent.com/1888809/38783820-96ba01e4-40bc-11e8-9f72-154f835abf7d.png)