### PR TITLE
Add ansible.compatibility_mode to the Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure("2") do |config|
         end
 
         config_develop.vm.provision :ansible do |ansible|
+            ansible.compatibility_mode = "2.0"
             ansible.inventory_path = "ansible/hosts-provision"
             ansible.playbook = "ansible/provision/playbook.yml"
             ansible.limit = "develop"
@@ -56,6 +57,7 @@ Vagrant.configure("2") do |config|
         # Ansible is only used to create a user, the rest is done on the
         # commandline with ansible-playbook commands.
         config_prodsim.vm.provision :ansible do |ansible|
+            ansible.compatibility_mode = "2.0"
             ansible.inventory_path = "ansible/hosts-provision"
             ansible.playbook = "ansible/setup_local_production_server.yml"
             ansible.limit = "prodsim"


### PR DESCRIPTION
This eliminates the warning about Vagrant guessing which version of Ansible is used.