### PR TITLE
Correct misspelled Showware for the large Shopware elephpant

### DIFF
--- a/src/Elewant/AppBundle/Resources/translations/herd.en.yml
+++ b/src/Elewant/AppBundle/Resources/translations/herd.en.yml
@@ -68,7 +68,7 @@ breed:
   BLUE_OPENGOODIES_LARGE: "OpenGoodies Blue (L)"
   BLUE_ORACLE_LARGE: "Oracle Blue (L)"
   BLUE_ORIGINAL_LARGE: "Original Blue (L)"
-  BLUE_SHOPWARE_LARGE: "Showware Blue (L)"
+  BLUE_SHOPWARE_LARGE: "Shopware Blue (L)"
   BLUE_ZEND_LARGE: "Zend Blue (L)"
   BLUE_ZRAY_LARGE: "Zray (L)"
   BROWN_TRUENORTHPHP_LARGE: "TrueNorthPHP (L)"


### PR DESCRIPTION
GH-185

Correct misspelling of the Large Shopware Elephpant