### PR TITLE
Add a first naive implementation of docker for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,27 @@ And eventually:
 
 Feel free to add anything you learn, no matter how small, to <docs/lessons_learned.md>
 
+Now choose how to get started, Docker or Vagrant:
 
-### Getting started
+### Getting started with Docker
+
+You will need docker on your local system:
+
+    [Docker](https://www.docker.com/)
+
+Run bin/setup.sh (only for the first time) and then Docker compose:
+
+    bin/setup.sh
+    docker-compose up -d
+
+You should be up-and-running!
+
+    http://localhost.elewant.com/
+
+> If you want to be able to log in with twitter, you'll need to create an application at app.twitter.com,
+then place your key & secret in `app/config/parameters.yml`.
+
+### Getting started with Vagrant
 
 You will need some tools on your local system:
 

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+cp -n docker/parameters.yml.dist app/config/parameters.yml
 docker-compose run php-fpm composer install
 docker-compose run php-fpm bin/console doctrine:migrations:migrate --no-interaction
 docker run --rm -ti -v $(pwd):/src:rw mkenney/npm:node-6.9-debian /usr/local/bin/npm install

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+docker-compose run php-fpm composer install
+docker-compose run php-fpm bin/console doctrine:migrations:migrate --no-interaction
+docker run --rm -ti -v $(pwd):/src:rw mkenney/npm:node-6.9-debian /usr/local/bin/npm install
+docker run --rm -ti -v $(pwd):/src:rw mkenney/npm:node-6.9-debian /usr/local/bin/grunt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+    database:
+        build: docker/mariadb
+        volumes:
+            - db:/var/lib/mysql
+        environment:
+            MYSQL_ROOT_PASSWORD: elewant
+            MYSQL_DATABASE: elewant
+            MYSQL_USER: elewant
+            MYSQL_PASSWORD: elewant
+    php-fpm:
+        build: docker/php-fpm
+        volumes:
+            - ./:/opt/project:cached
+        depends_on:
+          - database
+    webserver:
+        build: docker/nginx
+        ports:
+            - "80:80"
+        depends_on:
+          - php-fpm
+        volumes:
+            - ./:/opt/project:cached
+volumes:
+  db:

--- a/docker/mariadb/Dockerfile
+++ b/docker/mariadb/Dockerfile
@@ -1,0 +1,1 @@
+FROM mariadb:latest

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY site.conf /etc/nginx/conf.d/site.conf

--- a/docker/nginx/site.conf
+++ b/docker/nginx/site.conf
@@ -1,0 +1,22 @@
+server {
+    server_name elewant.loc;
+
+    listen      80;
+    root        /opt/project/web;
+
+    access_log  /dev/stderr;
+    error_log   /dev/stderr;
+
+    location / {
+        try_files $uri /app_dev.php?$args;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass     php-fpm:9000;
+        fastcgi_read_timeout 240;
+        fastcgi_index    app_dev.php;
+        fastcgi_param    SCRIPT_FILENAME    $document_root$fastcgi_script_name;
+        include          fastcgi_params;
+    }
+
+}

--- a/docker/nginx/site.conf
+++ b/docker/nginx/site.conf
@@ -1,5 +1,5 @@
 server {
-    server_name elewant.loc;
+    server_name localhost.elewant.com;
 
     listen      80;
     root        /opt/project/web;

--- a/docker/parameters.yml.dist
+++ b/docker/parameters.yml.dist
@@ -1,0 +1,25 @@
+parameters:
+
+    database_host:        database
+    database_port:        3306
+    database_unix_socket: /var/run/mysqld/mysqld.sock
+    database_name:        elewant
+    database_user:        elewant
+    database_password:    elewant
+
+    mailer_transport:        smtp
+    mailer_host:             127.0.0.1
+    mailer_user:             ~
+    mailer_password:         ~
+    mailer_delivery_address: ~
+
+    secret: SaG125fH0Alz8NIMIQdYGQEizoeZJVlQlbpFIDgEhQeyOalfPBkvowShgFkaruVu
+
+    twitter_client_id:     needs_twitter_id
+    twitter_client_secret: needs_twitter_secret
+
+    elewant_tweets_are_active:            false
+    elewant_tweets_app_consumerkey:       ~
+    elewant_tweets_app_consumersecret:    ~
+    elewant_tweets_app_accesstoken:       ~
+    elewant_tweets_app_accesstokensecret: ~

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:fpm-alpine
+
+# Install PDO_mysql
+RUN docker-php-ext-install pdo_mysql
+
+# Install Composer
+RUN apk --no-cache add zlib-dev \
+    && docker-php-ext-install zip
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+VOLUME /opt/project
+WORKDIR /opt/project

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -3,21 +3,6 @@
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
-// If you don't want to setup permissions the proper way, just uncomment the following PHP line
-// read https://symfony.com/doc/current/setup.html#checking-symfony-application-configuration-and-setup
-// for more information
-//umask(0000);
-
-// This check prevents access to debug front controllers that are deployed by accident to production servers.
-// Feel free to remove this, extend it, or make something more sophisticated.
-if (isset($_SERVER['HTTP_CLIENT_IP'])
-    || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1', '192.168.77.1'], true) || PHP_SAPI === 'cli-server')
-) {
-    header('HTTP/1.0 403 Forbidden');
-    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
-}
-
 require __DIR__.'/../vendor/autoload.php';
 Debug::enable();
 


### PR DESCRIPTION
This change makes it possible to use Docker for development, on the URL `localhost.elewant.com`.

The URL was chosen because A: Docker connects though a local port 127.0.0.1:80 and B: it's in the global DNS and therefore doesn't require a hostfile entry.

Feel free to test this setup by following the docs.