### PR TITLE
Add maintenance mode to nginx

### DIFF
--- a/ansible/provision/templates/nginx/prod-server.conf.j2
+++ b/ansible/provision/templates/nginx/prod-server.conf.j2
@@ -35,7 +35,16 @@ server {
     {% endfor %}
 
     location / {
+        if (-f $document_root/maintenance.html) {
+            return 503;
+        }
+
         try_files $uri /{{ item.index }}$is_args$args;
+    }
+
+    error_page 503 @maintenance;
+    location @maintenance {
+        rewrite ^(.*)$ /maintenance.html break;
     }
 
     location ~ \.php$ {


### PR DESCRIPTION
To activate maintenance mode add a `maintenance.html` file in the `public` dir.
If the file exists the maintenance file will be served.