### PR TITLE
Support unicode in JSON events (and allow import of old events)

### DIFF
--- a/config/packages/prooph_event_store.yaml
+++ b/config/packages/prooph_event_store.yaml
@@ -34,4 +34,4 @@ services:
         factory: ['@database_connection', getWrappedConnection]
 
     app.event_store.mariadb.persistence_strategy:
-        class: Prooph\EventStore\Pdo\PersistenceStrategy\MariaDbSingleStreamStrategy
+        class: Elewant\Tooling\Prooph\MariaDbSingleStreamStrategyWithUnescapedUnicode

--- a/src/Command/ImportOldEvents.php
+++ b/src/Command/ImportOldEvents.php
@@ -37,7 +37,7 @@ final class ImportOldEvents extends ContainerAwareCommand
     protected function configure()
     {
         $this->setName('event-store:event-stream:import-old-events')
-            ->setDescription('Import old events')
+            ->setDescription('Import old events (to be used once after upgrade and then removed)')
             ->setHelp('This command imports old events');
     }
 
@@ -58,10 +58,6 @@ final class ImportOldEvents extends ContainerAwareCommand
             ];
             $event['created_at']   = new DateTimeImmutable($event['created_at']);
             $event['payload']      = json_decode($event['payload'], true);
-
-            var_dump($event['payload']);
-            var_dump(json_encode($event['payload'], JSON_UNESCAPED_UNICODE));
-            var_dump(json_encode($event['payload'], JSON_UNESCAPED_UNICODE & JSON_UNESCAPED_SLASHES));
 
             $iterator = new \ArrayIterator(
                 [$this->messageFactory->createMessageFromArray($event['event_name'], $event)]

--- a/src/Elewant/Tooling/Prooph/MariaDbSingleStreamStrategyWithUnescapedUnicode.php
+++ b/src/Elewant/Tooling/Prooph/MariaDbSingleStreamStrategyWithUnescapedUnicode.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elewant\Tooling\Prooph;
+
+use Iterator;
+use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\Pdo\DefaultMessageConverter;
+use Prooph\EventStore\Pdo\HasQueryHint;
+use Prooph\EventStore\Pdo\MariaDBIndexedPersistenceStrategy;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
+use Prooph\EventStore\StreamName;
+
+final class MariaDbSingleStreamStrategyWithUnescapedUnicode implements PersistenceStrategy, HasQueryHint, MariaDBIndexedPersistenceStrategy
+{
+    /**
+     * @var MessageConverter
+     */
+    private $messageConverter;
+
+    public function __construct(?MessageConverter $messageConverter = null)
+    {
+        $this->messageConverter = $messageConverter ?? new DefaultMessageConverter();
+    }
+
+    /**
+     * @param string $tableName
+     * @return string[]
+     */
+    public function createSchema(string $tableName): array
+    {
+        $statement = <<<EOT
+CREATE TABLE `$tableName` (
+    `no` BIGINT(20) NOT NULL AUTO_INCREMENT,
+    `event_id` CHAR(36) COLLATE utf8mb4_bin NOT NULL,
+    `event_name` VARCHAR(100) COLLATE utf8mb4_bin NOT NULL,
+    `payload` LONGTEXT NOT NULL,
+    `metadata` LONGTEXT NOT NULL,
+    `created_at` DATETIME(6) NOT NULL,
+    `aggregate_version` INT(11) UNSIGNED GENERATED ALWAYS AS (JSON_EXTRACT(metadata, '$._aggregate_version')) STORED,
+    `aggregate_id` CHAR(36) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(metadata, '$._aggregate_id'))) STORED,
+    `aggregate_type` VARCHAR(150) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(metadata, '$._aggregate_type'))) STORED,
+    CHECK (`payload` IS NOT NULL AND JSON_VALID(`payload`)),
+    CHECK (`metadata` IS NOT NULL AND JSON_VALID(`metadata`)),
+    PRIMARY KEY (`no`),
+    UNIQUE KEY `ix_event_id` (`event_id`),
+    UNIQUE KEY `ix_unique_event` (`aggregate_type`, `aggregate_id`, `aggregate_version`),
+    KEY `ix_query_aggregate` (`aggregate_type`,`aggregate_id`,`no`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+EOT;
+
+        return [$statement];
+    }
+
+    public function columnNames(): array
+    {
+        return [
+            'event_id',
+            'event_name',
+            'payload',
+            'metadata',
+            'created_at',
+        ];
+    }
+
+    public function indexedMetadataFields(): array
+    {
+        return [
+            '_aggregate_id' => 'aggregate_id',
+            '_aggregate_type' => 'aggregate_type',
+            '_aggregate_version' => 'aggregate_version',
+        ];
+    }
+
+    public function prepareData(Iterator $streamEvents): array
+    {
+        $data = [];
+
+        foreach ($streamEvents as $event) {
+            $eventData = $this->messageConverter->convertToArray($event);
+
+            $data[] = $eventData['uuid'];
+            $data[] = $eventData['message_name'];
+            $data[] = json_encode($eventData['payload'], JSON_UNESCAPED_UNICODE);
+            $data[] = json_encode($eventData['metadata']);
+            $data[] = $eventData['created_at']->format('Y-m-d\TH:i:s.u');
+        }
+
+        return $data;
+    }
+
+    public function generateTableName(StreamName $streamName): string
+    {
+        return '_' . sha1($streamName->toString());
+    }
+
+    public function indexName(): string
+    {
+        return 'ix_query_aggregate';
+    }
+}

--- a/tests/AppBundle/Controller/ApiCommandFormHerdTest.php
+++ b/tests/AppBundle/Controller/ApiCommandFormHerdTest.php
@@ -17,7 +17,7 @@ class ApiCommandFormHerdTest extends ApiCommandBase
     {
         parent::setUp();
         $this->shepherdId = ShepherdId::generate();
-        $this->client     = $this->formHerd($this->shepherdId, 'My herd name');
+        $this->client     = $this->formHerd($this->shepherdId, 'My herd name 😱');
     }
 
     public function test_command_form_herd_returns_http_status_202()
@@ -32,7 +32,7 @@ class ApiCommandFormHerdTest extends ApiCommandBase
         /** @var HerdWasFormed $eventUnderTest */
         $eventUnderTest = $this->recordedEvents[0];
         TestCase::assertInstanceOf(HerdWasFormed::class, $eventUnderTest);
-        TestCase::assertSame('My herd name', $eventUnderTest->name());
+        TestCase::assertSame('My herd name 😱', $eventUnderTest->name());
     }
 
     public function test_command_form_herd_created_a_correct_herd_projection()


### PR DESCRIPTION
This PR solves a problem in unicode characters with the MariaDB persistence strategy of Prooph. I added a comment to an existing issues [here](https://github.com/prooph/pdo-event-store/issues/154), but in the meantime the code in this PR works by adding the `JSON_UNESCAPED_UNICODE` flag to the `json_encode()` of the payload.

The tests confirm this by using an unicode character in a herd name.

The import of existing events into the new event stream was testing with production data, and now also works. See #200 

