### PR TITLE
Add XDebug to docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,29 @@ services:
         volumes:
             - ./:/opt/project:cached
 
+    php-cli-xdebug:
+        build: docker/php-cli
+        depends_on:
+            - database
+        environment:
+            COMPOSER_HOME: "/home/.composer"
+            XDEBUG_CONFIG: "remote_host=host.docker.internal"
+            PHP_IDE_CONFIG: "serverName=localhost.elewant.com"
+            PHP_INI_SCAN_DIR: "/usr/local/etc/php/conf.d:/usr/local/etc/php/debug"
+        volumes:
+            - ./:/opt/project:cached
+
     php-fpm:
+        build: docker/php-fpm
+        depends_on:
+            - database
+        environment:
+            COMPOSER_HOME: "/home/.composer"
+            PHP_IDE_CONFIG: "serverName=localhost.elewant.com"
+        volumes:
+            - ./:/opt/project:cached
+
+    php-fpm-xdebug:
         build: docker/php-fpm
         depends_on:
             - database
@@ -30,6 +52,7 @@ services:
             COMPOSER_HOME: "/home/.composer"
             XDEBUG_CONFIG: "remote_host=host.docker.internal"
             PHP_IDE_CONFIG: "serverName=localhost.elewant.com"
+            PHP_INI_SCAN_DIR: "/usr/local/etc/php/conf.d:/usr/local/etc/php/debug"
         volumes:
             - ./:/opt/project:cached
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
         build: docker/php-cli
         depends_on:
             - database
+        environment:
+            COMPOSER_HOME: "/home/.composer"
+            XDEBUG_CONFIG: "remote_host=host.docker.internal"
+            PHP_IDE_CONFIG: "serverName=localhost.elewant.com"
         volumes:
             - ./:/opt/project:cached
 
@@ -22,6 +26,10 @@ services:
         build: docker/php-fpm
         depends_on:
             - database
+        environment:
+            COMPOSER_HOME: "/home/.composer"
+            XDEBUG_CONFIG: "remote_host=host.docker.internal"
+            PHP_IDE_CONFIG: "serverName=localhost.elewant.com"
         volumes:
             - ./:/opt/project:cached
 

--- a/docker/nginx/site.conf
+++ b/docker/nginx/site.conf
@@ -1,3 +1,10 @@
+resolver 127.0.0.11;
+
+map $cookie_XDEBUG_SESSION $my_fastcgi_pass {
+    default php-fpm;
+    PHPSTORM php-fpm-xdebug;
+}
+
 server {
     server_name localhost.elewant.com;
 
@@ -12,7 +19,7 @@ server {
     }
 
     location ~ \.php$ {
-        fastcgi_pass     php-fpm:9000;
+        fastcgi_pass     $my_fastcgi_pass:9000;
         fastcgi_read_timeout 240;
         fastcgi_index    index.php;
         fastcgi_param    SCRIPT_FILENAME    $document_root$fastcgi_script_name;

--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -3,6 +3,15 @@ FROM php:cli-alpine
 # Install PDO_mysql
 RUN docker-php-ext-install pdo_mysql
 
+# Install, configure, enable Xdebug
+RUN apk --no-cache add --virtual .build-dependencies \
+        autoconf \
+        g++ \
+        make \
+    && pecl install xdebug-2.6.1 \
+    && apk --no-cache del .build-dependencies
+COPY xdebug.ini ${PHP_INI_DIR}/conf.d/xdebug.ini
+
 # Install Composer
 RUN apk --no-cache add zlib-dev \
     && docker-php-ext-install zip

--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -3,7 +3,7 @@ FROM php:cli-alpine
 # Install PDO_mysql
 RUN docker-php-ext-install pdo_mysql
 
-# Install, configure, enable Xdebug
+# Install, configure, but do not enable Xdebug
 RUN apk --no-cache add --virtual .build-dependencies \
         autoconf \
         g++ \
@@ -11,6 +11,9 @@ RUN apk --no-cache add --virtual .build-dependencies \
     && pecl install xdebug-2.6.1 \
     && apk --no-cache del .build-dependencies
 COPY xdebug.ini ${PHP_INI_DIR}/conf.d/xdebug.ini
+
+# Allow XDebug enable by setting PHP_INI_SCAN_DIR
+COPY xdebug-enable.ini ${PHP_INI_DIR}/debug/xdebug-enable.ini
 
 # Install Composer
 RUN apk --no-cache add zlib-dev \

--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:cli-alpine
+FROM php:7.2-cli-alpine
 
 # Install PDO_mysql
 RUN docker-php-ext-install pdo_mysql

--- a/docker/php-cli/xdebug-enable.ini
+++ b/docker/php-cli/xdebug-enable.ini
@@ -1,0 +1,1 @@
+zend_extension=xdebug.so

--- a/docker/php-cli/xdebug.ini
+++ b/docker/php-cli/xdebug.ini
@@ -1,4 +1,3 @@
-zend_extension=xdebug.so
 xdebug.coverage_enable=0
 xdebug.remote_enable=1
 xdebug.remote_autostart=1

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -3,7 +3,7 @@ FROM php:fpm-alpine
 # Install PDO_mysql
 RUN docker-php-ext-install pdo_mysql
 
-# Install, configure, enable Xdebug
+# Install, configure, but do not enable Xdebug
 RUN apk --no-cache add --virtual .build-dependencies \
         autoconf \
         g++ \
@@ -11,6 +11,9 @@ RUN apk --no-cache add --virtual .build-dependencies \
     && pecl install xdebug-2.6.1 \
     && apk --no-cache del .build-dependencies
 COPY xdebug.ini ${PHP_INI_DIR}/conf.d/xdebug.ini
+
+# Allow XDebug enable by setting PHP_INI_SCAN_DIR
+COPY xdebug-enable.ini ${PHP_INI_DIR}/debug/xdebug-enable.ini
 
 # Install Composer
 RUN apk --no-cache add zlib-dev \

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:fpm-alpine
+FROM php:7.2-fpm-alpine
 
 # Install PDO_mysql
 RUN docker-php-ext-install pdo_mysql

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -3,6 +3,15 @@ FROM php:fpm-alpine
 # Install PDO_mysql
 RUN docker-php-ext-install pdo_mysql
 
+# Install, configure, enable Xdebug
+RUN apk --no-cache add --virtual .build-dependencies \
+        autoconf \
+        g++ \
+        make \
+    && pecl install xdebug-2.6.1 \
+    && apk --no-cache del .build-dependencies
+COPY xdebug.ini ${PHP_INI_DIR}/conf.d/xdebug.ini
+
 # Install Composer
 RUN apk --no-cache add zlib-dev \
     && docker-php-ext-install zip

--- a/docker/php-fpm/xdebug-enable.ini
+++ b/docker/php-fpm/xdebug-enable.ini
@@ -1,0 +1,1 @@
+zend_extension=xdebug.so

--- a/docker/php-fpm/xdebug.ini
+++ b/docker/php-fpm/xdebug.ini
@@ -1,4 +1,3 @@
-zend_extension=xdebug.so
 xdebug.coverage_enable=0
 xdebug.remote_enable=1
 xdebug.remote_autostart=1


### PR DESCRIPTION
Add XDebug to docker. For obvious reasons.

This can do with an enable/disable mechanism later.