### PR TITLE
Add link to the fieldguide to the correct translation tag

### DIFF
--- a/src/Elewant/Webapp/Application/Resources/templates/Herd/tending.html.twig
+++ b/src/Elewant/Webapp/Application/Resources/templates/Herd/tending.html.twig
@@ -70,7 +70,7 @@
                 <div class="modal-body">
                     <div class="row mt-2">
                         <div class="col">
-                            {% trans %}
+                            {% trans with {'%link%': '<a href="http://afieldguidetoelephpants.net/#index" target="_blank" rel="noopener noreferrer">A Field Guide to Elephpants</a>'} %}
                                 adopting-help-text
                             {% endtrans %}
                         </div>
@@ -128,7 +128,7 @@
                 <div class="modal-body">
                     <div class="row mt-2">
                         <div class="col">
-                            {% trans with {'%link%': '<a href="http://afieldguidetoelephpants.net/#index" target="_blank" rel="noopener noreferrer">A Field Guide to Elephpants</a>'} %}
+                            {% trans %}
                                 desiring-help-text
                             {% endtrans %}
                         </div>


### PR DESCRIPTION
The link ot the fieldguide was set on the wrong translation tag, resulting in %link% in the text.