### PR TITLE
Improved docker tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /.web-server-pid
 /ansible/provision/group_vars/develop/override_locally.yml
 /node_modules/
+/phpspec.yml
+/phpunit.xml
 /public/build/
 /public/bundles/
 /vendor/

--- a/README.md
+++ b/README.md
@@ -56,10 +56,34 @@ You should be up-and-running!
 > If you want to be able to log in with twitter, you'll need to create an application at app.twitter.com,
 then place your key & secret in `.env.local`.
 
-#### Running tests
+#### Running commands inside docker containers
 
-    bin/docker_run_tests
+Run `ls` inside the default container (`php-cli`):
 
+    bin/docker ls
+
+Run `ls` inside the default container of the testing environment:
+
+    bin/docker-test ls
+
+Print usage:
+
+    bin/docker
+    bin/docker-test
+
+Running Symfony Console:
+
+    bin/docker bin/console c:c
+    bin/docker-test bin/console c:c
+
+Running vendor binaries:
+
+    bin/docker vendor/bin/phpunit
+    bin/docker-test vendor/bin/phpunit
+
+#### Running all tests
+
+    bin/docker-test bin/run_tests
 
 ### Getting started with Vagrant
 

--- a/bin/docker
+++ b/bin/docker
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Define these yourself!
+default="php-cli"
+runners=("php-cli" "php-cli-xdebug")
+
+# Determine compose file
+if [[ -z "${COMPOSE_FILE}" ]]; then
+    COMPOSE_FILE="docker-compose.yml"
+fi
+
+# Autodetect services
+services=($(docker-compose -f "${COMPOSE_FILE}" config --services))
+
+# Colors
+red="\e[31m"
+yellow="\e[33m"
+reset="\e[0m"
+
+# Methods
+function print_usage {
+    echo "Usage: ${0} [SERVICE] COMMAND..."
+    echo -e "  SERVICE: One of ${yellow}${services[@]}${reset} (default: ${yellow}${default}${reset})"
+    echo -e "  COMMAND: The command to run in the container"
+    exit 128
+}
+
+function in_array {
+    for e in "${@:2}"; do
+        [[ "${e}" == "${1}" ]] && echo 1 && return
+    done
+    echo 0
+}
+
+# Print usage if no arguments were passed
+if [[ "${#}" -eq 0 ]]; then
+    print_usage
+fi
+
+# Determine if first argument is a service
+if [[ $(in_array "${1}" "${services[@]}") -eq 1 ]]; then
+    service_given=1
+    service="${1}"
+    command=("${@:2}")
+else
+    service_given=0
+    service="${default}"
+    command=("${@}")
+fi
+
+# Print error if service was passed but no other arguments (no command)
+if [[ ${service_given} -eq 1 ]]; then
+    if [[ "${#}" -eq 1 ]]; then
+        echo -e "${red}Service was not followed by a command${reset}"
+        print_usage
+    fi
+fi
+
+# If service is a one-shot command runner, run command (and remove container), then exit
+if [[ $(in_array "${service}" "${runners[@]}") -eq 1 ]]; then
+    echo -e "==> Running ${yellow}${command[@]}${reset} on ${yellow}${service}${reset}"
+    docker-compose -f "${COMPOSE_FILE}" --log-level=ERROR run --rm "${service}" "${command[@]}"
+    exit ${?}
+fi
+
+# If service isn't up, bring it up
+if [[ -z $(docker ps -q --no-trunc | grep "$(docker-compose -f "${COMPOSE_FILE}" ps -q "${service}")") ]]; then
+    echo -e "==> Bringing ${yellow}${service}${reset} up"
+    docker-compose -f "${COMPOSE_FILE}" --log-level=ERROR up -d
+fi
+
+# Execute command
+echo -e "==> Executing ${yellow}${command[@]}${reset} on ${yellow}${service}${reset}"
+docker-compose -f "${COMPOSE_FILE}" --log-level=ERROR exec "${service}" "${command[@]}"

--- a/bin/docker-test
+++ b/bin/docker-test
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+COMPOSE_FILE="docker-compose-test.yml" bin/docker "${@}"

--- a/bin/docker_console
+++ b/bin/docker_console
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-docker-compose up -d && \
-  docker-compose run php-cli bin/console "$@"

--- a/bin/docker_run_tests
+++ b/bin/docker_run_tests
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-docker-compose -f docker-compose-test.yml up -d && \
-  docker-compose -f docker-compose-test.yml run php-cli bin/run_tests


### PR DESCRIPTION
I find it a hassle to remember what to type when I want to run something specific in a Docker container. Things can become overly long and complicated, like:

```
$ docker-compose -f docker-compose-test.yml --log-level=ERROR run php-cli vendor/bin/phpspec run
```

This PR introduces 2 new scripts:

```
$ bin/docker
Usage: bin/docker [SERVICE] COMMAND...
  SERVICE: One of database php-cli php-cli-xdebug php-fpm php-fpm-xdebug herd-projection webserver (default: php-cli)
  COMMAND: The command to run in the container
```

```
$ bin/docker-test 
Usage: bin/docker-test [SERVICE] COMMAND...
  SERVICE: One of database-test php-cli (default: php-cli)
  COMMAND: The command to run in the container
```

Which enable you to do the same as before with just this:

```
$ bin/docker-test vendor/bin/phpspec run
```