### PR TITLE
Do Not Merge: Allow unknown breeds

### DIFF
--- a/specs/Elewant/Herding/DomainModel/Breed/BreedCollectionSpec.php
+++ b/specs/Elewant/Herding/DomainModel/Breed/BreedCollectionSpec.php
@@ -67,6 +67,12 @@ final class BreedCollectionSpec extends ObjectBehavior
         $this->equals($expected)->shouldReturn(true);
     }
 
+    public function it_does_not_add_unknown_breeds(): void
+    {
+        $this->add(Breed::fromString('UNKNOWN_BREED'));
+        $this->isEmpty()->shouldReturn(true);
+    }
+
     public function it_removes_breeds(): void
     {
         $confoo = Breed::fromString(Breed::WHITE_CONFOO_LARGE);

--- a/specs/Elewant/Herding/DomainModel/Breed/BreedSpec.php
+++ b/specs/Elewant/Herding/DomainModel/Breed/BreedSpec.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Elewant\Herding\DomainModel\Breed;
 
-use Elewant\Herding\DomainModel\SorryThatIsAnInvalid;
 use PhpSpec\ObjectBehavior;
 
 final class BreedSpec extends ObjectBehavior
@@ -20,13 +19,16 @@ final class BreedSpec extends ObjectBehavior
     {
         $this->beConstructedThrough('fromString', ['BLUE_ORIGINAL_REGULAR']);
         $this->shouldHaveType(Breed::class);
+        $this->isUnknown()->shouldReturn(false);
         $this->toString()->shouldReturn('BLUE_ORIGINAL_REGULAR');
     }
 
-    public function it_does_not_construct_an_invalid_type(): void
+    public function it_is_unknown_when_given_an_invalid_type(): void
     {
         $this->beConstructedThrough('fromString', ['invalid']);
-        $this->shouldThrow(SorryThatIsAnInvalid::class)->duringInstantiation();
+        $this->shouldHaveType(Breed::class);
+        $this->isUnknown()->shouldReturn(true);
+        $this->toString()->shouldReturn('UNKNOWN');
     }
 
     public function it_equals_another_or_not(): void

--- a/specs/Elewant/Herding/DomainModel/Herd/HerdSpec.php
+++ b/specs/Elewant/Herding/DomainModel/Herd/HerdSpec.php
@@ -51,6 +51,12 @@ final class HerdSpec extends ObjectBehavior
         $this->elePHPants()->shouldContainAnElePHPant(Breed::blueOriginalRegular());
     }
 
+    public function it_ignores_adoption_of_an_unknown_breed(): void
+    {
+        $this->adoptElePHPant(Breed::fromString('UNKNOWN_BREED'));
+        $this->elePHPants()->shouldHaveCount(0);
+    }
+
     public function it_adopts_two_new_elephpants(): void
     {
         $this->adoptElePHPant(Breed::blueOriginalRegular());
@@ -71,6 +77,15 @@ final class HerdSpec extends ObjectBehavior
         $this->elePHPants()->shouldHaveCount(1);
         $this->elePHPants()->shouldNotContainAnElePHPant(Breed::blueOriginalRegular());
         $this->elePHPants()->shouldContainAnElePHPant(Breed::greenZf2Regular());
+    }
+
+    public function it_ignores_abandonment_of_an_unknown_breed(): void
+    {
+        $this->adoptElePHPant(Breed::blueOriginalRegular());
+        $this->elePHPants()->shouldHaveCount(1);
+
+        $this->abandonElePHPant(Breed::fromString('UNKNOWN_BREED'));
+        $this->elePHPants()->shouldHaveCount(1);
     }
 
     public function it_abandons_the_same_breed_twice(): void
@@ -175,6 +190,12 @@ final class HerdSpec extends ObjectBehavior
 
         $this->desiredBreeds()->shouldHaveCount(1);
         $this->desiredBreeds()->contains(Breed::blueOriginalRegular())->shouldReturn(true);
+    }
+
+    public function it_ignores_desires_for_an_unknown_breed(): void
+    {
+        $this->desireBreed(Breed::fromString('UNKNOWN_BREED'));
+        $this->desiredBreeds()->shouldHaveCount(0);
     }
 
     public function it_can_eliminate_the_desire_for_a_new_breed(): void

--- a/src/Elewant/Herding/DomainModel/Breed/Breed.php
+++ b/src/Elewant/Herding/DomainModel/Breed/Breed.php
@@ -114,7 +114,7 @@ final class Breed
     public static function fromString(string $type): self
     {
         if (!in_array($type, self::availableTypes(), true)) {
-            throw SorryThatIsAnInvalid::breed($type);
+            $type = 'UNKNOWN';
         }
 
         return new self($type);
@@ -156,5 +156,10 @@ final class Breed
     public function __toString(): string
     {
         return $this->toString();
+    }
+
+    public function isUnknown(): bool
+    {
+        return $this->type === 'UNKNOWN';
     }
 }

--- a/src/Elewant/Herding/DomainModel/Breed/BreedCollection.php
+++ b/src/Elewant/Herding/DomainModel/Breed/BreedCollection.php
@@ -80,6 +80,10 @@ final class BreedCollection implements Countable, IteratorAggregate
             return;
         }
 
+        if ($breed->isUnknown()) {
+            return;
+        }
+
         $this->breeds[] = $breed;
     }
 

--- a/src/Elewant/Herding/DomainModel/Herd/Herd.php
+++ b/src/Elewant/Herding/DomainModel/Herd/Herd.php
@@ -267,6 +267,10 @@ final class Herd extends AggregateRoot
 
     private function applyAnElePHPantWasAdoptedByHerd(ElePHPantId $elePHPantId, Breed $breed): void
     {
+        if ($breed->isUnknown()) {
+            return;
+        }
+
         $this->breeds->add($breed);
         $this->elePHPants[] = ElePHPant::appear($elePHPantId, $breed);
     }
@@ -320,6 +324,10 @@ final class Herd extends AggregateRoot
      */
     private function guardContainsThisBreed(Breed $breed): void
     {
+        if ($breed->isUnknown()) {
+            return;
+        }
+
         foreach ($this->elePHPants() as $elePHPant) {
             if ($breed->equals($elePHPant->breed())) {
                 return;

--- a/src/Elewant/Herding/DomainModel/SorryThatIsAnInvalid.php
+++ b/src/Elewant/Herding/DomainModel/SorryThatIsAnInvalid.php
@@ -22,9 +22,4 @@ final class SorryThatIsAnInvalid extends Exception
     {
         return new self(sprintf('Sorry, %s is an invalid ElePHPantId', $elePHPantId));
     }
-
-    public static function breed(string $breed): self
-    {
-        return new self(sprintf('Sorry, %s is an invalid Breed', $breed));
-    }
 }

--- a/src/Elewant/Webapp/Infrastructure/ProophProjections/HerdReadModel.php
+++ b/src/Elewant/Webapp/Infrastructure/ProophProjections/HerdReadModel.php
@@ -122,6 +122,10 @@ final class HerdReadModel extends AbstractReadModel
         DateTimeImmutable $adoptedOn
     ): void
     {
+        if ($breed->isUnknown()) {
+            return;
+        }
+
         $this->connection->insert(
             self::TABLE_ELEPHPANT,
             [
@@ -156,6 +160,10 @@ final class HerdReadModel extends AbstractReadModel
      */
     public function onBreedWasDesiredByHerd(HerdId $herdId, Breed $breed, DateTimeImmutable $desiredOn): void
     {
+        if ($breed->isUnknown()) {
+            return;
+        }
+
         try {
             $this->connection->insert(
                 self::TABLE_DESIRED_BREEDS,


### PR DESCRIPTION
This is the work required to allow a previously existing `Breed` (where events have been recorded in history) to be removed from the Breed values but not break the Herd domain model.

Personally, I don't like this change, it adds a bunch of if-statements that essentially mean having a no-op - while we still have to deal with those events in later releases of this product (with new projections or other interactions with the historical events).

But it is an interesting case that started with the removal of a Breed that never existed in the real world in #231 