### PR TITLE
Change db servername in .env file

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ APP_SECRET=ac11e9b102ad3d038f7dacfed7b22608
 # Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # Configure your db driver and server_version in config/packages/doctrine.yaml
-DATABASE_URL='mysql://elewant:elewant@192.168.77.77/elewant'
+DATABASE_URL='mysql://elewant:elewant@database/elewant'
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/swiftmailer-bundle ###


### PR DESCRIPTION
Closed #246 

As the main installation is using docker, use the database docker service name in `.env` file (as it's the case in the `.env.test`